### PR TITLE
use vercel-edge.com in tests

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -1,4 +1,4 @@
 require('jest-fetch-mock').enableMocks();
 
 process.env.VERCEL_EDGE_CONFIG =
-  'https://vercel-edge-config.com/edge-config/edgeConfigId1/secret1';
+  'https://vercel-edge.com/edge-config/edgeConfigId1/secret1';

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -11,7 +11,7 @@ describe('default Edge Config', () => {
   describe('test conditions', () => {
     it('should have an env var called VERCEL_EDGE_CONFIG', () => {
       expect(baseUrl).toEqual(
-        'https://vercel-edge-config.com/edge-config/edgeConfigId1/secret1',
+        'https://vercel-edge.com/edge-config/edgeConfigId1/secret1',
       );
     });
   });
@@ -158,7 +158,7 @@ describe('default Edge Config', () => {
 // "default Edge Config" tests above anyhow
 describe('createEdgeConfig', () => {
   const modifiedBaseUrl =
-    'https://vercel-edge-config.com/edge-config/edgeConfigId2/secret2';
+    'https://vercel-edge.com/edge-config/edgeConfigId2/secret2';
   let edgeConfig: EdgeConfig;
 
   beforeEach(() => {


### PR DESCRIPTION
Moving to `vercel-edge.com` following the discussion in 
 https://vercel.slack.com/archives/C03LF48T3B7/p1657264360523819