### PR TITLE
add 404 handling

### DIFF
--- a/.changeset/nine-rats-think.md
+++ b/.changeset/nine-rats-think.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': patch
+---
+
+Throw when attempting to read value of non-existing Edge Config

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -56,9 +56,27 @@ describe('default Edge Config', () => {
 
     describe('when the item does not exist', () => {
       it('should return undefined', async () => {
-        fetchMock.mockResponse('', { status: 404 });
+        fetchMock.mockResponse('', {
+          status: 404,
+          headers: { 'x-edge-config-digest': 'fake' },
+        });
 
         await expect(get('foo')).resolves.toEqual(undefined);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/item/foo`, {
+          headers: { Authorization: 'Bearer token-1' },
+        });
+      });
+    });
+
+    describe('when the edge config does not exist', () => {
+      it('should return undefined', async () => {
+        fetchMock.mockResponse('', { status: 404 });
+
+        await expect(get('foo')).rejects.toThrowError(
+          '@vercel/edge-config: Edge Config does not exist',
+        );
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/item/foo`, {
@@ -177,9 +195,28 @@ describe('default Edge Config', () => {
 
     describe('when the item does not exist', () => {
       it('should return false', async () => {
-        fetchMock.mockResponse('', { status: 404 });
+        fetchMock.mockResponse('', {
+          status: 404,
+          headers: { 'x-edge-config-digest': 'fake' },
+        });
 
         await expect(has('foo')).resolves.toEqual(false);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/item/foo`, {
+          method: 'HEAD',
+          headers: { Authorization: 'Bearer token-1' },
+        });
+      });
+    });
+
+    describe('when the edge config does not exist', () => {
+      it('should return false', async () => {
+        fetchMock.mockResponse('', { status: 404 });
+
+        await expect(has('foo')).rejects.toThrowError(
+          '@vercel/edge-config: Edge Config does not exist',
+        );
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/item/foo`, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,7 +196,14 @@ export function createEdgeConfigClient(
         undefined
       >(
         async (res) => {
-          if (res.status === 404) return undefined;
+          if (res.status === 404) {
+            // if the x-edge-config-digest header is present, it means
+            // the edge config exists, but the item does not
+            if (res.headers.has('x-edge-config-digest')) return undefined;
+            // if the x-edge-config-digest header is not present, it means
+            // the edge config itself does not exist
+            throw new Error('@vercel/edge-config: Edge Config does not exist');
+          }
           if (res.ok) return res.json();
           throw new Error('@vercel/edge-config: Unexpected error');
         },
@@ -209,7 +216,14 @@ export function createEdgeConfigClient(
       assertIsKey(key);
       return fetch(`${url}/item/${key}`, { method: 'HEAD', headers }).then(
         (res) => {
-          if (res.status === 404) return false;
+          if (res.status === 404) {
+            // if the x-edge-config-digest header is present, it means
+            // the edge config exists, but the item does not
+            if (res.headers.has('x-edge-config-digest')) return false;
+            // if the x-edge-config-digest header is not present, it means
+            // the edge config itself does not exist
+            throw new Error('@vercel/edge-config: Edge Config does not exist');
+          }
           if (res.ok) return true;
           throw new Error('@vercel/edge-config: Unexpected error');
         },
@@ -237,7 +251,11 @@ export function createEdgeConfigClient(
         headers,
       }).then<T | undefined, undefined>(
         async (res) => {
-          if (res.status === 404) return undefined;
+          if (res.status === 404) {
+            // the /items endpoint will never return 404, so
+            // the 404 can only mean the Edge Config itself does not exist
+            throw new Error('@vercel/edge-config: Edge Config does not exist');
+          }
           if (res.ok) return res.json();
           throw new Error('@vercel/edge-config: Unexpected error');
         },


### PR DESCRIPTION
> This PR is a temporary solution to at least introduce the notion of the edge config itself not existing. 

For now we can use the `x-edge-config-digest` header to distinguish between the 404s we are getting.

When reading `/item/:key` we receive
- a 404 without an `x-edge-config-digest` header when the edge config itself does not exist (this should ultimately be a 401, as you can't have a valid token for an edge config that does not exist)
- a 404 with an `x-edge-config-digest` header if the edge config exists, the token is valid but the item does not exist


Before being able to distinguish these errors better, we need to fix it in the servers upstream. We need to provide error details in the 404 response body. We will do so in https://linear.app/vercel/issue/FLA-253/handle-404s-properly.