### PR TITLE
change npm access to public

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.changeset/shy-tomatoes-kneel.md
+++ b/.changeset/shy-tomatoes-kneel.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': patch
+---
+
+make package publicly available again


### PR DESCRIPTION
Seems like changeset has switched the package back to restricted access on npm due the this configuration error.

Setting it back to `public` and publishing a patch changeset so the package gets republished.