### PR TITLE
loosen types

### DIFF
--- a/.changeset/happy-bobcats-drop.md
+++ b/.changeset/happy-bobcats-drop.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': patch
+---
+
+loosen edge config item value type to be "any"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
-import type { EdgeConfigItemValue, EmbeddedEdgeConfig } from './types';
-
-export type { EdgeConfigItemValue } from './types';
+import type { EmbeddedEdgeConfig } from './types';
 
 declare global {
   /* eslint-disable camelcase */
@@ -116,10 +114,10 @@ function getLocalEdgeConfig(edgeConfigId: string): EmbeddedEdgeConfig | null {
  * Edge Config Client
  */
 export interface EdgeConfigClient {
-  get: <T extends EdgeConfigItemValue>(key: string) => Promise<T | undefined>;
-  getAll: <T extends Record<string, EdgeConfigItemValue>>(
-    keys?: (keyof T)[],
-  ) => Promise<T | undefined>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get: <T = any>(key: string) => Promise<T | undefined>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getAll: <T = any>(keys?: (keyof T)[]) => Promise<T | undefined>;
   has: (key: string) => Promise<boolean>;
   digest: () => Promise<string>;
 }
@@ -157,9 +155,8 @@ export function createEdgeConfigClient(
     // return api which uses the local edge config if one exists
     if (localEdgeConfig) {
       return {
-        get<T extends EdgeConfigItemValue>(
-          key: string,
-        ): Promise<T | undefined> {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        async get<T = any>(key: string): Promise<T | undefined> {
           assertIsDefined(localEdgeConfig); // always defined, but make ts happy
           assertIsKey(key);
 
@@ -169,9 +166,8 @@ export function createEdgeConfigClient(
           // This makes it consistent with the real API.
           return Promise.resolve(clone(localEdgeConfig.items[key]) as T);
         },
-        async getAll<T extends Record<string, EdgeConfigItemValue>>(
-          keys?: (keyof T)[],
-        ): Promise<T | undefined> {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        async getAll<T = any>(keys?: (keyof T)[]): Promise<T | undefined> {
           assertIsDefined(localEdgeConfig);
           assertIsKeys(keys);
 
@@ -193,9 +189,8 @@ export function createEdgeConfigClient(
   }
 
   return {
-    async get<T extends EdgeConfigItemValue>(
-      key: string,
-    ): Promise<T | undefined> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async get<T = any>(key: string): Promise<T | undefined> {
       assertIsKey(key);
       return fetch(`${url}/item/${key}`, { headers }).then<
         T | undefined,
@@ -241,9 +236,8 @@ export function createEdgeConfigClient(
         },
       );
     },
-    async getAll<T extends Record<string, EdgeConfigItemValue>>(
-      keys?: (keyof T)[],
-    ): Promise<T | undefined> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async getAll<T = any>(keys?: (keyof T)[]): Promise<T | undefined> {
       if (Array.isArray(keys)) assertIsKeys(keys);
 
       const search = Array.isArray(keys)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,5 @@
-export type EdgeConfigItemValue =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string | number]: EdgeConfigItemValue }
-  | EdgeConfigItemValue[];
-
 export interface EmbeddedEdgeConfig {
   digest: string;
-  items: Record<string, EdgeConfigItemValue>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  items: Record<string, any>;
 }


### PR DESCRIPTION
Before this change typescript would complain about the following legitimate code

```ts
interface Tiger {
  name: string;
}
const tiger = await get<Tiger>('animal');
```

We were over-prescriptive with our types.

I'm not 100% sure about using `any`. It is inspired by `JSON.parse()` also returning `any`.
At least it's not getting in the way of legitimate usage with `any`.