### PR TITLE
avoid build time warning

### DIFF
--- a/.changeset/tiny-pens-film.md
+++ b/.changeset/tiny-pens-film.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': patch
+---
+
+avoid build time warning aboud Node.js module being loaded when used in Next.js

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -434,12 +434,10 @@ describe('createEdgeConfig', () => {
         process.env.AWS_LAMBDA_FUNCTION_NAME = 'some-value';
 
         // mock fs for test
-        jest.mock('fs', () => {
+        jest.mock('fs/promises', () => {
           return {
-            promises: {
-              readFile: (): Promise<string> => {
-                return Promise.resolve(JSON.stringify(embeddedEdgeConfig));
-              },
+            readFile: (): Promise<string> => {
+              return Promise.resolve(JSON.stringify(embeddedEdgeConfig));
             },
           };
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,10 +88,20 @@ async function getLocalEdgeConfig(
   // skip in Edge Runtime, as it has no fs
   if (typeof EdgeRuntime === 'string') return null;
 
-  // eslint-disable-next-line unicorn/prefer-node-protocol
-  const fs = await import('fs');
+  // import "fs/promises"
+  const fs = (await import(
+    // Joining here avoids this warning:
+    //   A Node.js module is loaded ('fs/promises' at line 1) which is not
+    //   upported in the Edge Runtime
+    //
+    // This is fine as this code never runs inside of EdgeRuntime due to the
+    // check above
+    ['fs', 'promises'].join('/')
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  )) as typeof import('fs/promises');
+
   try {
-    const content = await fs.promises.readFile(
+    const content = await fs.readFile(
       `/opt/edge-configs/${edgeConfigId}.json`,
       'utf-8',
     );


### PR DESCRIPTION
Avoids the following warning

```
A Node.js module is loaded ('fs/promises' at line 1) which is not supported in the Edge Runtime.
```