### PR TITLE
use distinct 404 error codes

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -56,8 +56,8 @@ describe('default Edge Config', () => {
         fetchMock.mockResponse(
           JSON.stringify({
             error: {
-              code: 'not_found',
-              message: 'Could not find the edge config item',
+              code: 'edge_config_item_not_found',
+              message: 'Could not find the edge config item: foo',
             },
           }),
           {
@@ -83,8 +83,8 @@ describe('default Edge Config', () => {
         fetchMock.mockResponse(
           JSON.stringify({
             error: {
-              code: 'not_found',
-              message: 'Could not find the edge config',
+              code: 'edge_config_not_found',
+              message: 'Could not find the edge config: ecfg-1',
             },
           }),
           { status: 404, headers: { 'content-type': 'application/json' } },
@@ -168,8 +168,8 @@ describe('default Edge Config', () => {
         fetchMock.mockResponse(
           JSON.stringify({
             error: {
-              code: 'not_found',
-              message: 'Could not find the edge config',
+              code: 'edge_config_not_found',
+              message: 'Could not find the edge config: ecfg-1',
             },
           }),
           { status: 404, headers: { 'content-type': 'application/json' } },
@@ -238,8 +238,8 @@ describe('default Edge Config', () => {
         fetchMock.mockResponse(
           JSON.stringify({
             error: {
-              code: 'not_found',
-              message: 'Could not find the edge config item',
+              code: 'edge_config_item_not_found',
+              message: 'Could not find the edge config item: foo',
             },
           }),
           {
@@ -266,8 +266,8 @@ describe('default Edge Config', () => {
         fetchMock.mockResponse(
           JSON.stringify({
             error: {
-              code: 'not_found',
-              message: 'Could not find the edge config',
+              code: 'edge_config_not_found',
+              message: 'Could not find the edge config: ecfg-1',
             },
           }),
           { status: 404, headers: { 'content-type': 'application/json' } },


### PR DESCRIPTION
Adapts the tests to the new distinct error codes:
- `edge_config_not_found` when an edge config does not exist
- `edge_config_item_not_found` when an edge config item does not exist

The logic itself does not need to change as we do not actually rely on the error code in the client.
