### PR TITLE
use digest directly

### DIFF
--- a/.changeset/heavy-lamps-visit.md
+++ b/.changeset/heavy-lamps-visit.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': patch
+---
+
+fix digest response body parsing as it has changed upstream

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -309,7 +309,7 @@ describe('default Edge Config', () => {
   describe('/', () => {
     describe('when the request succeeds', () => {
       it('should return the digest', async () => {
-        fetchMock.mockResponse(JSON.stringify({ digest: 'awe1' }));
+        fetchMock.mockResponse(JSON.stringify('awe1'));
 
         await expect(digest()).resolves.toEqual('awe1');
 
@@ -430,7 +430,7 @@ describe('createEdgeConfig', () => {
     describe('digest()', () => {
       describe('when the request succeeds', () => {
         it('should return the digest', async () => {
-          fetchMock.mockResponse(JSON.stringify({ digest: 'awe1' }));
+          fetchMock.mockResponse(JSON.stringify('awe1'));
 
           await expect(edgeConfig.digest()).resolves.toEqual('awe1');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,7 +291,7 @@ export function createClient(
       return fetch(`${url}/digest?version=1`, { headers }).then(
         (res) => {
           if (!res.ok) throw new Error(ERRORS.UNEXPECTED);
-          return res.json().then((data: { digest: string }) => data.digest);
+          return res.json() as Promise<string>;
         },
         () => {
           throw new Error(ERRORS.NETWORK);


### PR DESCRIPTION
The `/digest` endpoint now returns the digest directly instead of `{ digest }`, so we need to adapt the handler.