### PR TITLE
README: update `edge` to `experimental-edge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ export default (req) => {
   return new Response(`someKey contains value "${value})"`);
 };
 
-export const config = { runtime: 'experimental-edge' };
+export const config = { runtime: 'edge' };
 ```
 
 ## Caught a Bug?


### PR DESCRIPTION
With Next.js v13.0.7, API routes can specify the Edge Runtime as `edge` (and no longer need to be `experimental-edge`).

Since we recommend `next@canary`, update our example to simply use `edge`.