### PR TITLE
only assert keys in getAll when necessary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -254,11 +254,12 @@ export function createClient(
         }
 
         if (localEdgeConfig) {
-          assertIsKeys(keys);
+          if (keys === undefined) {
+            return Promise.resolve(clone(localEdgeConfig.items) as T);
+          }
 
-          return Array.isArray(keys)
-            ? Promise.resolve(clone(pick(localEdgeConfig.items, keys)) as T)
-            : Promise.resolve(clone(localEdgeConfig.items) as T);
+          assertIsKeys(keys);
+          return Promise.resolve(clone(pick(localEdgeConfig.items, keys)) as T);
         }
       }
 


### PR DESCRIPTION
addresses issue #60 where overzealous assertion prevents use of getAll to "get all" 😆

