### PR TITLE
improves type generics for `get` and `getAll`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,13 @@
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [x: string]: JsonValue }
+  | JsonValue[];
+
+export type EdgeConfigValue = JsonValue;
+
 export interface EmbeddedEdgeConfig {
   digest: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
I noticed that the type generics for `get` and `getAll` can be improved to be more accurate and restrictive (especially for `getAll`).

First, let's define the following type — edge config is basically a json store, so any value in the edge config must be a valid JSON value.

```ts
type JsonValue =
  | string
  | number
  | boolean
  | null
  | { [x: string]: JsonValue }
  | JsonValue[];

export type EdgeConfigValue = JsonValue;
```
## `getAll`

### Previous type definition for `getAll`:

```ts
getAll: <T = any>(keys?: (keyof T)[]) => Promise<T | undefined>;
```

Issues: 
* It's incorrect to allow the response to be any type. We know that `getAll` always returns a record (JSON object), so the return type should be typed as a `Record`. Currently,  calling `getAll<string>` would return a response `string`, which is never possible. The return type should actually be more like `Record<string, string>`.
* We can default `T` to `EdgeConfigValue`.
* If `keys` is defined, we can infer the keys of the Record based on the `keys` that's passed in. 

Examples:
```ts
const a = await getAll()
// a: any
// expected: a: Record<string, JsonValue>

const b = await getAll<string>()
// b: string
// expected: b: Record<string, string>

const c = await getAll(['foo', 'bar'])
// c: any
// expected: c: Partial<Record<'foo' | 'bar', JsonValue>>
```

### New type definition:
```ts
  getAll: <
    T extends EdgeConfigValue = EdgeConfigValue,
    K extends string = string,
  >(
    keys?: K[],
  ) => Promise<Partial<Record<K, T>> | undefined>;
```

Examples: 
```ts
const a = await getAll()
// a: Partial<Record<string, EdgeConfigValue>> | undefined

const b = await getAll<string>()
// b: Partial<Record<string, string>> | undefined

const c = await getAll(['foo', 'bar'])
// c: Partial<Record<'foo' | 'bar', EdgeConfigValue>> | undefined
```

Note: I wrapped the Record in `Partial` because the keys are not guaranteed to exist. For example:
```ts
// edge config: { x: 'x' }

const a = await getAll(['foo']) // returns {}
// a.x = undefined
```

## `get`

Before:
```ts
get: <T = any>(key: string) => Promise<T | undefined>;
```

After:
```ts
  get: <T extends EdgeConfigValue = EdgeConfigValue>(
    key: string,
  ) => Promise<T | undefined>;
```

P.S. I didn't see any contributing guidelines but I just went ahead and made a PR, hopefully y'all don't mind!