### PR TITLE
chore: remove `urlpattern-polyfill` from jest setup.js

### DIFF
--- a/packages/edge-config/jest/setup.js
+++ b/packages/edge-config/jest/setup.js
@@ -1,4 +1,3 @@
 require('jest-fetch-mock').enableMocks();
-require('urlpattern-polyfill');
 
 process.env.EDGE_CONFIG = 'https://edge-config.vercel.com/ecfg-1?token=token-1';

--- a/packages/edge-config/package.json
+++ b/packages/edge-config/package.json
@@ -62,8 +62,7 @@
     "ts-jest": "29.0.5",
     "tsconfig": "workspace:*",
     "tsup": "6.6.3",
-    "typescript": "4.9.5",
-    "urlpattern-polyfill": "6.0.2"
+    "typescript": "4.9.5"
   },
   "engines": {
     "node": ">=14.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,9 +85,6 @@ importers:
       typescript:
         specifier: 4.9.5
         version: 4.9.5
-      urlpattern-polyfill:
-        specifier: 6.0.2
-        version: 6.0.2
 
   packages/eslint-config-custom:
     dependencies:
@@ -7139,12 +7136,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.0
-
-  /urlpattern-polyfill@6.0.2:
-    resolution: {integrity: sha512-5vZjFlH9ofROmuWmXM9yj2wljYKgWstGwe8YTyiqM7hVum/g9LyCizPZtb3UqsuppVwety9QJmfc42VggLpTgg==}
-    dependencies:
-      braces: 3.0.2
-    dev: true
 
   /utf-8-validate@6.0.3:
     resolution: {integrity: sha512-uIuGf9TWQ/y+0Lp+KGZCMuJWc3N9BHA+l/UmHd/oUHwJJDeysyTRxNQVkbzsIWfGFbRe3OcgML/i0mvVRPOyDA==}


### PR DESCRIPTION
It appears that the use of URLPattern is unnecessary, URLPattern has not been used since this commit: https://github.com/vercel/storage/commit/0c78c58412b73640df98f9eec6122dd22ee6b0dc.
