### PR TITLE
avoid process.version warning in edge runtime

### DIFF
--- a/.changeset/empty-coats-boil.md
+++ b/.changeset/empty-coats-boil.md
@@ -1,0 +1,5 @@
+---
+'@vercel/kv': patch
+---
+
+avoid process.version warning in edge runtime

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -44,7 +44,7 @@
     "testEnvironment": "node"
   },
   "dependencies": {
-    "@upstash/redis": "1.20.2"
+    "@upstash/redis": "1.20.6"
   },
   "devDependencies": {
     "@babel/core": "7.19.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
   packages/kv:
     dependencies:
       '@upstash/redis':
-        specifier: 1.20.2
-        version: 1.20.2
+        specifier: 1.20.6
+        version: 1.20.6
     devDependencies:
       '@babel/core':
         specifier: 7.19.6
@@ -2054,8 +2054,8 @@ packages:
       '@typescript-eslint/types': 5.59.1
       eslint-visitor-keys: 3.4.0
 
-  /@upstash/redis@1.20.2:
-    resolution: {integrity: sha512-9QS/SypDxeeh672H7dEEmuYOX5TtPYnaDLlhxWJEPd8LzcEQ6hohwDJuojpqGkvvvrK58mlWOkN1GrMxbXPTeQ==}
+  /@upstash/redis@1.20.6:
+    resolution: {integrity: sha512-q1izaYEUsq/WiXNOjf4oOjFZe8fIeBSZN8d5cEyOD4nem+zxc4jccieorQQrNlEahKPE1ZYLzVEkMODRUfch2g==}
     dependencies:
       isomorphic-fetch: 3.0.0
     transitivePeerDependencies:


### PR DESCRIPTION
avoids this warning by upgrading the `@upstash/redis` package

![image](https://user-images.githubusercontent.com/1765075/236211921-1642e24e-dd7d-4033-b1d1-c2dc7a9c2cfc.png)


fixes in `@upstash/redis`
- https://github.com/upstash/upstash-redis/pull/346
- https://github.com/upstash/upstash-redis/pull/347