### PR TITLE
feat: Better docs for Vite folks

### DIFF
--- a/.changeset/flat-horses-flow.md
+++ b/.changeset/flat-horses-flow.md
@@ -1,0 +1,8 @@
+---
+'@vercel/edge-config': patch
+'@vercel/kv': patch
+'@vercel/postgres': patch
+'@vercel/postgres-kysely': patch
+---
+
+feat: Docs section for Vite environment config

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -136,7 +136,7 @@ export default defineConfig(({ mode }) => {
   // This check is important!
   if (mode === 'development') {
     const env = loadEnv(mode, process.cwd(), '');
-    dotenvExpand.expand(env);
+    dotenvExpand.expand({ parsed: env });
   }
 
   return {

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -119,7 +119,8 @@ As always, you can run the tests using: `npm test`
 
 `@vercel/edge-config` reads database credentials from `process.env`. With some tools, process.env is automatically populated from your `.env` file during development (created when you run `vc env pull`), but Vite does not expose `.env` variables on `process.env.`
 
-You can fix this in one of two ways. Firstly, you can populate `process.env` yourself using something like `dotenv-expand`:
+You can fix this in **one** of following two ways:
+1. You can populate `process.env` yourself using something like `dotenv-expand`:
 
 ```shell
 pnpm install --save-dev dotenv dotenv-expand

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -117,41 +117,33 @@ As always, you can run the tests using: `npm test`
 
 ## A note for Vite users
 
-`@vercel/edge-config` is zero-config for platforms where `process.env` is available. It is _technically_ available in Vite, but one major caveat: **Vite only reads variables starting with `VITE_` from your `.env` files -- this is to avoid accidentally bundling your secrets into client code**. Practically, this means that this library _will_ work zero-config when deployed to production (where `process.env` is available on the server, but not on the client), but will _not_ work while you're developing locally, because Vite will not add your environment variables (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`, etc) from your `.env` file.
+`@vercel/edge-config` reads database credentials from `process.env`. With some tools, process.env is automatically populated from your `.env` file during development (created when you run `vc env pull`), but Vite does not expose `.env` variables on `process.env.`
 
-To combat this, you have one of two options:
-
-### Add dotenv-expand to your dev command (but _not_ your build command!)
-
-This will load your sensitive environment variables into `process.env` during dev, but allow Vite to safely omit them during build.
+You can fix this in one of two ways. Firstly, you can populate `process.env` yourself using something like `dotenv-expand`:
 
 ```shell
 pnpm install --save-dev dotenv dotenv-expand
 ```
 
 ```js
-// an example vite.config.js from a SvelteKit app
-import { sveltekit } from '@sveltejs/kit/vite';
-import dotenv from 'dotenv';
+// vite.config.js
 import dotenvExpand from 'dotenv-expand';
-import { defineConfig } from 'vite';
+import { loadEnv, defineConfig } from 'vite';
 
 export default defineConfig(({ mode }) => {
   // This check is important!
   if (mode === 'development') {
-    const env = dotenv.config();
+    const env = loadEnv(mode);
     dotenvExpand.expand(env);
   }
 
   return {
-    plugins: [sveltekit()],
+    ...
   };
 });
 ```
 
-### Configure your client manually
-
-If you're developing in a framework that provides private environment variable access, such as SvelteKit, instead of relying on `@vercel/edge-config` to find your config via environment variables, you can feed it the values it needs (here's an example from earlier):
+Secondly, you can provide the credentials explicitly, instead of relying on zero-config setup. For example, here's how you could create a client in SvelteKit, which makes private environment variables available via `$env/static/private`:
 
 ```diff
 import { createClient } from '@vercel/edge-config';

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -143,7 +143,7 @@ export default defineConfig(({ mode }) => {
 });
 ```
 
-Secondly, you can provide the credentials explicitly, instead of relying on zero-config setup. For example, here's how you could create a client in SvelteKit, which makes private environment variables available via `$env/static/private`:
+2. You can provide the credentials explicitly, instead of relying on a zero-config setup. For example, this is how you could create a client in SvelteKit, which makes private environment variables available via `$env/static/private`:
 
 ```diff
 import { createClient } from '@vercel/edge-config';

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -135,7 +135,7 @@ import { loadEnv, defineConfig } from 'vite';
 export default defineConfig(({ mode }) => {
   // This check is important!
   if (mode === 'development') {
-    const env = loadEnv(mode);
+    const env = loadEnv(mode, process.cwd(), '');
     dotenvExpand.expand(env);
   }
 

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -117,9 +117,10 @@ As always, you can run the tests using: `npm test`
 
 ## A note for Vite users
 
-`@vercel/edge-config` reads database credentials from `process.env`. With some tools, process.env is automatically populated from your `.env` file during development (created when you run `vc env pull`), but Vite does not expose `.env` variables on `process.env.`
+`@vercel/edge-config` reads database credentials from the environment variables on `process.env`. In general, `process.env` is automatically populated from your `.env` file during development, which is created when you run `vc env pull`. However, Vite does not expose the `.env` variables on `process.env.`
 
 You can fix this in **one** of following two ways:
+
 1. You can populate `process.env` yourself using something like `dotenv-expand`:
 
 ```shell

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -114,3 +114,50 @@ export const config = { runtime: 'edge' };
 3. Within the module you want to test your local development instance of `@vercel/edge-config`, just link it to the dependencies: `npm link @vercel/edge-config`. Instead of the default one from npm, Node.js will now use your clone of `@vercel/edge-config`!
 
 As always, you can run the tests using: `npm test`
+
+## A note for Vite users
+
+`@vercel/edge-config` is zero-config for platforms where `process.env` is available. It is _technically_ available in Vite, but one major caveat: **Vite only reads variables starting with `VITE_` from your `.env` files -- this is to avoid accidentally bundling your secrets into client code**. Practically, this means that this library _will_ work zero-config when deployed to production (where `process.env` is available on the server, but not on the client), but will _not_ work while you're developing locally, because Vite will not add your environment variables (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`, etc) from your `.env` file.
+
+To combat this, you have one of two options:
+
+### Add dotenv-expand to your dev command (but _not_ your build command!)
+
+This will load your sensitive environment variables into `process.env` during dev, but allow Vite to safely omit them during build.
+
+```shell
+pnpm install --save-dev dotenv dotenv-expand
+```
+
+```js
+// an example vite.config.js from a SvelteKit app
+import { sveltekit } from '@sveltejs/kit/vite';
+import dotenv from 'dotenv';
+import dotenvExpand from 'dotenv-expand';
+import { defineConfig } from 'vite';
+
+export default defineConfig(({ mode }) => {
+  // This check is important!
+  if (mode === 'development') {
+    const env = dotenv.config();
+    dotenvExpand.expand(env);
+  }
+
+  return {
+    plugins: [sveltekit()],
+  };
+});
+```
+
+### Configure your client manually
+
+If you're developing in a framework that provides private environment variable access, such as SvelteKit, instead of relying on `@vercel/edge-config` to find your config via environment variables, you can feed it the values it needs (here's an example from earlier):
+
+```diff
+import { createClient } from '@vercel/edge-config';
++ import { EDGE_CONFIG } from '$env/static/private';
+
+- const edgeConfig = createClient(process.env.ANOTHER_EDGE_CONFIG);
++ const edgeConfig = createClient(EDGE_CONFIG);
+await edgeConfig.get('someKey');
+```

--- a/packages/kv/README.md
+++ b/packages/kv/README.md
@@ -70,13 +70,13 @@ await kv.set('key', 'value');
 
 See the [documentation](https://www.vercel.com/docs/storage/vercel-kv) for details.
 
-### A note for Vite users
+## A note for Vite users
 
 `@vercel/kv` is zero-config for platforms where `process.env` is available. It is _technically_ available in Vite, but one major caveat: **Vite only reads variables starting with `VITE_` from your `.env` files -- this is to avoid accidentally bundling your secrets into client code**. Practically, this means that this library _will_ work zero-config when deployed to production (where `process.env` is available on the server, but not on the client), but will _not_ work while you're developing locally, because Vite will not add your environment variables (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`, etc) from your `.env` file.
 
 To combat this, you have one of two options:
 
-#### Add dotenv-expand to your dev command (but _not_ your build command!)
+### Add dotenv-expand to your dev command (but _not_ your build command!)
 
 This will load your sensitive environment variables into `process.env` during dev, but allow Vite to safely omit them during build.
 
@@ -104,7 +104,7 @@ export default defineConfig(({ mode }) => {
 });
 ```
 
-#### Configure your client manually
+### Configure your client manually
 
 If you're developing in a framework that provides private environment variable access, such as SvelteKit, instead of relying on `@vercel/kv` to find your config via environment variables, you can feed it the values it needs (here's an example from earlier):
 

--- a/packages/kv/README.md
+++ b/packages/kv/README.md
@@ -72,9 +72,11 @@ See the [documentation](https://www.vercel.com/docs/storage/vercel-kv) for detai
 
 ## A note for Vite users
 
-`@vercel/kv` reads database credentials from `process.env`. With some tools, process.env is automatically populated from your `.env` file during development (created when you run `vc env pull`), but Vite does not expose `.env` variables on `process.env.`
+`@vercel/kv` reads database credentials from the environment variables on `process.env`. In general, `process.env` is automatically populated from your `.env` file during development, which is created when you run `vc env pull`. However, Vite does not expose the `.env` variables on `process.env.`
 
-You can fix this in one of two ways. Firstly, you can populate `process.env` yourself using something like `dotenv-expand`:
+You can fix this in **one** of following two ways:
+
+1. You can populate `process.env` yourself using something like `dotenv-expand`:
 
 ```shell
 pnpm install --save-dev dotenv dotenv-expand
@@ -98,7 +100,7 @@ export default defineConfig(({ mode }) => {
 });
 ```
 
-Secondly, you can provide the credentials explicitly, instead of relying on zero-config setup. For example, here's how you could create a client in SvelteKit, which makes private environment variables available via `$env/static/private`:
+2. You can provide the credentials explicitly, instead of relying on a zero-config setup. For example, this is how you could create a client in SvelteKit, which makes private environment variables available via `$env/static/private`:
 
 ```diff
 import { createClient } from '@vercel/kv';

--- a/packages/kv/README.md
+++ b/packages/kv/README.md
@@ -69,3 +69,55 @@ await kv.set('key', 'value');
 ## Docs
 
 See the [documentation](https://www.vercel.com/docs/storage/vercel-kv) for details.
+
+### A note for Vite users
+
+`@vercel/kv` is zero-config for platforms where `process.env` is available. It is _technically_ available in Vite, but one major caveat: **Vite only reads variables starting with `VITE_` from your `.env` files -- this is to avoid accidentally bundling your secrets into client code**. Practically, this means that this library _will_ work zero-config when deployed to production (where `process.env` is available on the server, but not on the client), but will _not_ work while you're developing locally, because Vite will not add your environment variables (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`, etc) from your `.env` file.
+
+To combat this, you have one of two options:
+
+#### Add dotenv-expand to your dev command (but _not_ your build command!)
+
+This will load your sensitive environment variables into `process.env` during dev, but allow Vite to safely omit them during build.
+
+```shell
+pnpm install --save-dev dotenv dotenv-expand
+```
+
+```js
+// an example vite.config.js from a SvelteKit app
+import { sveltekit } from '@sveltejs/kit/vite';
+import dotenv from 'dotenv';
+import dotenvExpand from 'dotenv-expand';
+import { defineConfig } from 'vite';
+
+export default defineConfig(({ mode }) => {
+  // This check is important!
+  if (mode === 'development') {
+    const env = dotenv.config();
+    dotenvExpand.expand(env);
+  }
+
+  return {
+    plugins: [sveltekit()],
+  };
+});
+```
+
+#### Configure your client manually
+
+If you're developing in a framework that provides private environment variable access, such as SvelteKit, instead of relying on `@vercel/kv` to find your config via environment variables, you can feed it the values it needs (here's an example from earlier):
+
+```diff
+import { createClient } from '@vercel/kv';
++ import { KV_URL, KV_REST_API_TOKEN } from '$env/static/private';
+
+const kv = createClient({
+-  url: 'https://<hostname>.redis.vercel-storage.com',
+-  token: '<token>',
++  url: KV_URL,
++  token: KV_REST_API_TOKEN,
+});
+
+await kv.set('key', 'value');
+```

--- a/packages/kv/README.md
+++ b/packages/kv/README.md
@@ -90,7 +90,7 @@ import { loadEnv, defineConfig } from 'vite';
 export default defineConfig(({ mode }) => {
   // This check is important!
   if (mode === 'development') {
-    const env = loadEnv(mode);
+    const env = loadEnv(mode, process.cwd(), '');
     dotenvExpand.expand(env);
   }
 

--- a/packages/kv/README.md
+++ b/packages/kv/README.md
@@ -91,7 +91,7 @@ export default defineConfig(({ mode }) => {
   // This check is important!
   if (mode === 'development') {
     const env = loadEnv(mode, process.cwd(), '');
-    dotenvExpand.expand(env);
+    dotenvExpand.expand({ parsed: env });
   }
 
   return {

--- a/packages/postgres-kysely/README.md
+++ b/packages/postgres-kysely/README.md
@@ -121,7 +121,7 @@ import { loadEnv, defineConfig } from 'vite';
 export default defineConfig(({ mode }) => {
   // This check is important!
   if (mode === 'development') {
-    const env = loadEnv(mode);
+    const env = loadEnv(mode, process.cwd(), '');
     dotenvExpand.expand(env);
   }
 

--- a/packages/postgres-kysely/README.md
+++ b/packages/postgres-kysely/README.md
@@ -122,7 +122,7 @@ export default defineConfig(({ mode }) => {
   // This check is important!
   if (mode === 'development') {
     const env = loadEnv(mode, process.cwd(), '');
-    dotenvExpand.expand(env);
+    dotenvExpand.expand({ parsed: env });
   }
 
   return {

--- a/packages/postgres-kysely/README.md
+++ b/packages/postgres-kysely/README.md
@@ -103,9 +103,11 @@ When using the `createClient` or `createPool` functions, you can pass in additio
 
 ### A note for Vite users
 
-`@vercel/postgres-kysely` reads database credentials from `process.env`. With some tools, process.env is automatically populated from your `.env` file during development (created when you run `vc env pull`), but Vite does not expose `.env` variables on `process.env.`
+`@vercel/postgres-kysely` reads database credentials from the environment variables on `process.env`. In general, `process.env` is automatically populated from your `.env` file during development, which is created when you run `vc env pull`. However, Vite does not expose the `.env` variables on `process.env.`
 
-You can fix this in one of two ways. Firstly, you can populate `process.env` yourself using something like `dotenv-expand`:
+You can fix this in **one** of following two ways:
+
+1. You can populate `process.env` yourself using something like `dotenv-expand`:
 
 ```shell
 pnpm install --save-dev dotenv dotenv-expand
@@ -129,7 +131,7 @@ export default defineConfig(({ mode }) => {
 });
 ```
 
-Secondly, you can provide the credentials explicitly, instead of relying on zero-config setup. For example, here's how you could create a client in SvelteKit, which makes private environment variables available via `$env/static/private`:
+2. You can provide the credentials explicitly, instead of relying on a zero-config setup. For example, this is how you could create a client in SvelteKit, which makes private environment variables available via `$env/static/private`:
 
 ```diff
 import { createKysely } from '@vercel/postgres-kysely';

--- a/packages/postgres-kysely/README.md
+++ b/packages/postgres-kysely/README.md
@@ -103,41 +103,33 @@ When using the `createClient` or `createPool` functions, you can pass in additio
 
 ### A note for Vite users
 
-`@vercel/postgres-kysely` is zero-config for platforms where `process.env` is available. It is _technically_ available in Vite, but one major caveat: **Vite only reads variables starting with `VITE_` from your `.env` files -- this is to avoid accidentally bundling your secrets into client code**. Practically, this means that this library _will_ work zero-config when deployed to production (where `process.env` is available on the server, but not on the client), but will _not_ work while you're developing locally, because Vite will not add your environment variables (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`, etc) from your `.env` file.
+`@vercel/postgres-kysely` reads database credentials from `process.env`. With some tools, process.env is automatically populated from your `.env` file during development (created when you run `vc env pull`), but Vite does not expose `.env` variables on `process.env.`
 
-To combat this, you have one of two options:
-
-#### Add dotenv-expand to your dev command (but _not_ your build command!)
-
-This will load your sensitive environment variables into `process.env` during dev, but allow Vite to safely omit them during build.
+You can fix this in one of two ways. Firstly, you can populate `process.env` yourself using something like `dotenv-expand`:
 
 ```shell
 pnpm install --save-dev dotenv dotenv-expand
 ```
 
 ```js
-// an example vite.config.js from a SvelteKit app
-import { sveltekit } from '@sveltejs/kit/vite';
-import dotenv from 'dotenv';
+// vite.config.js
 import dotenvExpand from 'dotenv-expand';
-import { defineConfig } from 'vite';
+import { loadEnv, defineConfig } from 'vite';
 
 export default defineConfig(({ mode }) => {
   // This check is important!
   if (mode === 'development') {
-    const env = dotenv.config();
+    const env = loadEnv(mode);
     dotenvExpand.expand(env);
   }
 
   return {
-    plugins: [sveltekit()],
+    ...
   };
 });
 ```
 
-#### Configure your client manually
-
-If you're developing in a framework that provides private environment variable access, such as SvelteKit, instead of relying on `@vercel/postgres-kysely` to find your config via environment variables, you can feed it the values it needs (here's an example from earlier):
+Secondly, you can provide the credentials explicitly, instead of relying on zero-config setup. For example, here's how you could create a client in SvelteKit, which makes private environment variables available via `$env/static/private`:
 
 ```diff
 import { createKysely } from '@vercel/postgres-kysely';

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -111,7 +111,7 @@ import { loadEnv, defineConfig } from 'vite';
 export default defineConfig(({ mode }) => {
   // This check is important!
   if (mode === 'development') {
-    const env = loadEnv(mode);
+    const env = loadEnv(mode, process.cwd(), '');
     dotenvExpand.expand(env);
   }
 

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -112,7 +112,7 @@ export default defineConfig(({ mode }) => {
   // This check is important!
   if (mode === 'development') {
     const env = loadEnv(mode, process.cwd(), '');
-    dotenvExpand.expand(env);
+    dotenvExpand.expand({ parsed: env });
   }
 
   return {

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -90,3 +90,52 @@ When using the `createClient` or `createPool` functions, you can pass in additio
 
 The `@vercel/postgres` package uses the `pg` package. For
 more detailed documentation, checkout [node-postgres](https://node-postgres.com/).
+
+### A note for Vite users
+
+`@vercel/postgres` is zero-config for platforms where `process.env` is available. It is _technically_ available in Vite, but one major caveat: **Vite only reads variables starting with `VITE_` from your `.env` files -- this is to avoid accidentally bundling your secrets into client code**. Practically, this means that this library _will_ work zero-config when deployed to production (where `process.env` is available on the server, but not on the client), but will _not_ work while you're developing locally, because Vite will not add your environment variables (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`, etc) from your `.env` file.
+
+To combat this, you have one of two options:
+
+#### Add dotenv-expand to your dev command (but _not_ your build command!)
+
+This will load your sensitive environment variables into `process.env` during dev, but allow Vite to safely omit them during build.
+
+```shell
+pnpm install --save-dev dotenv dotenv-expand
+```
+
+```js
+// an example vite.config.js from a SvelteKit app
+import { sveltekit } from '@sveltejs/kit/vite';
+import dotenv from 'dotenv';
+import dotenvExpand from 'dotenv-expand';
+import { defineConfig } from 'vite';
+
+export default defineConfig(({ mode }) => {
+  // This check is important!
+  if (mode === 'development') {
+    const env = dotenv.config();
+    dotenvExpand.expand(env);
+  }
+
+  return {
+    plugins: [sveltekit()],
+  };
+});
+```
+
+#### Configure your client manually
+
+If you're developing in a framework that provides private environment variable access, such as SvelteKit, instead of relying on `@vercel/postgres` to find your config via environment variables, you can feed it the values it needs (here's an example from earlier):
+
+```diff
+import { createPool } from '@vercel/postgres';
++ import { POSTGRES_URL } from '$env/static/private';
+
+import { createPool } from '@vercel/postgres';
+const pool = createPool({
+-  /* config */
++  connectionString: POSTGRES_URL
+});
+```

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -93,9 +93,11 @@ more detailed documentation, checkout [node-postgres](https://node-postgres.com/
 
 ### A note for Vite users
 
-`@vercel/postgres` reads database credentials from `process.env`. With some tools, process.env is automatically populated from your `.env` file during development (created when you run `vc env pull`), but Vite does not expose `.env` variables on `process.env.`
+`@vercel/postgres` reads database credentials from the environment variables on `process.env`. In general, `process.env` is automatically populated from your `.env` file during development, which is created when you run `vc env pull`. However, Vite does not expose the `.env` variables on `process.env.`
 
-You can fix this in one of two ways. Firstly, you can populate `process.env` yourself using something like `dotenv-expand`:
+You can fix this in **one** of following two ways:
+
+1. You can populate `process.env` yourself using something like `dotenv-expand`:
 
 ```shell
 pnpm install --save-dev dotenv dotenv-expand
@@ -119,7 +121,7 @@ export default defineConfig(({ mode }) => {
 });
 ```
 
-Secondly, you can provide the credentials explicitly, instead of relying on zero-config setup. For example, here's how you could create a client in SvelteKit, which makes private environment variables available via `$env/static/private`:
+2. You can provide the credentials explicitly, instead of relying on a zero-config setup. For example, this is how you could create a client in SvelteKit, which makes private environment variables available via `$env/static/private`:
 
 ```diff
 import { createPool } from '@vercel/postgres';

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -93,41 +93,33 @@ more detailed documentation, checkout [node-postgres](https://node-postgres.com/
 
 ### A note for Vite users
 
-`@vercel/postgres` is zero-config for platforms where `process.env` is available. It is _technically_ available in Vite, but one major caveat: **Vite only reads variables starting with `VITE_` from your `.env` files -- this is to avoid accidentally bundling your secrets into client code**. Practically, this means that this library _will_ work zero-config when deployed to production (where `process.env` is available on the server, but not on the client), but will _not_ work while you're developing locally, because Vite will not add your environment variables (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`, etc) from your `.env` file.
+`@vercel/postgres` reads database credentials from `process.env`. With some tools, process.env is automatically populated from your `.env` file during development (created when you run `vc env pull`), but Vite does not expose `.env` variables on `process.env.`
 
-To combat this, you have one of two options:
-
-#### Add dotenv-expand to your dev command (but _not_ your build command!)
-
-This will load your sensitive environment variables into `process.env` during dev, but allow Vite to safely omit them during build.
+You can fix this in one of two ways. Firstly, you can populate `process.env` yourself using something like `dotenv-expand`:
 
 ```shell
 pnpm install --save-dev dotenv dotenv-expand
 ```
 
 ```js
-// an example vite.config.js from a SvelteKit app
-import { sveltekit } from '@sveltejs/kit/vite';
-import dotenv from 'dotenv';
+// vite.config.js
 import dotenvExpand from 'dotenv-expand';
-import { defineConfig } from 'vite';
+import { loadEnv, defineConfig } from 'vite';
 
 export default defineConfig(({ mode }) => {
   // This check is important!
   if (mode === 'development') {
-    const env = dotenv.config();
+    const env = loadEnv(mode);
     dotenvExpand.expand(env);
   }
 
   return {
-    plugins: [sveltekit()],
+    ...
   };
 });
 ```
 
-#### Configure your client manually
-
-If you're developing in a framework that provides private environment variable access, such as SvelteKit, instead of relying on `@vercel/postgres` to find your config via environment variables, you can feed it the values it needs (here's an example from earlier):
+Secondly, you can provide the credentials explicitly, instead of relying on zero-config setup. For example, here's how you could create a client in SvelteKit, which makes private environment variables available via `$env/static/private`:
 
 ```diff
 import { createPool } from '@vercel/postgres';


### PR DESCRIPTION
Added a snippet explaining how to set up our clients with Vite (this has been the #1 issue filing reason thus far):

[`@vercel/postgres-kysely`](https://github.com/vercel/storage/blob/d996962dcdebf1a1e720ccceefed0049a2b6db41/packages/postgres-kysely/README.md)
[`@vercel/postgres`](https://github.com/vercel/storage/blob/d996962dcdebf1a1e720ccceefed0049a2b6db41/packages/postgres/README.md)
[`@vercel/kv`](https://github.com/vercel/storage/blob/d996962dcdebf1a1e720ccceefed0049a2b6db41/packages/kv/README.md)
[`@vercel/edge-config`](https://github.com/vercel/storage/blob/d996962dcdebf1a1e720ccceefed0049a2b6db41/packages/edge-config/README.md)