### PR TITLE
fix: Prevent incorrect call of tagged literal `sql`

### DIFF
--- a/.changeset/famous-pillows-lick.md
+++ b/.changeset/famous-pillows-lick.md
@@ -1,0 +1,5 @@
+---
+'@vercel/postgres': minor
+---
+
+feat: Prevent incorrect usage of tagged literal `sql` for non-ts users


### PR DESCRIPTION
This will throw:

``sql(`SELECT * FROM users\`);``

this will not:

``sql`SELECT * FROM users`;``

I accidentally pushed the initial commit to `main`, which shouldn't have even been possible. I've updated repository settings to disallow that. But for now, just look at the diff of this commit:
https://github.com/vercel/storage/commit/adae6c93c6a30511905abe440e35b10f252b2c0e