### PR TITLE
Simplify sqlTemplate loop + better guards

### DIFF
--- a/.changeset/dry-bees-reflect.md
+++ b/.changeset/dry-bees-reflect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/postgres': patch
+---
+
+chore: Simplify `sqlTemplate`

--- a/packages/postgres/src/sql-template.ts
+++ b/packages/postgres/src/sql-template.ts
@@ -12,14 +12,11 @@ export function sqlTemplate(
       "It looks like you tried to call `sql` as a function. Make sure to use it as a tagged template.\n\tExample: sql`SELECT * FROM users`, not sql('SELECT * FROM users')",
     );
   }
-  let result = '';
 
-  for (let i = 0; i < strings.length; i++) {
-    result += strings[i];
+  let [result] = strings;
 
-    if (i < values.length) {
-      result += `$${i + 1}`;
-    }
+  for (let i = 1; i < strings.length; i++) {
+    result += `$${i}${strings[i]}`;
   }
 
   return [result, values];

--- a/packages/postgres/src/sql-template.ts
+++ b/packages/postgres/src/sql-template.ts
@@ -13,10 +13,11 @@ export function sqlTemplate(
     );
   }
 
-  let [result] = strings;
+  // ts tries to annotate `strings` with `& any[]` because of the prior check which breaks the type
+  let result = (strings as TemplateStringsArray)[0] ?? '';
 
   for (let i = 1; i < strings.length; i++) {
-    result += `$${i}${strings[i]}`;
+    result += `$${i}${(strings as TemplateStringsArray)[i] ?? ''}`;
   }
 
   return [result, values];


### PR DESCRIPTION
This MR would like to improve the `sqlTemplate` tag in the following way:

  * if the template is valid, in no circumstance a *tag* receives a template with a `length` less than at least one entry
  * if the template is an *array* but any of the following is true, let the driver throw an appropriate and related error
    * the array is empty and `undefined` as string would throw at the driver level
    * the `values` has no index at `${i - 1}`, hence the *tag* was misused and the driver will throw an error
  * there's no need to check `i < values.length` anymore as that doesn't fully guard against possible creation of wrong *SQL* statements (i.e. fake template array and less values actually *could* potentially lead to undesired queries)
  * because of all previous points, there's no need neither to `i + 1` in the loop