### PR TITLE
feat: `unsafeUnescaped` for unsafe parameterization of SQL queries

### DIFF
--- a/.changeset/brown-dodos-sparkle.md
+++ b/.changeset/brown-dodos-sparkle.md
@@ -1,0 +1,6 @@
+---
+'@vercel/postgres': minor
+---
+
+feat: Allow `unsafeUnescaped` insertions into `sql` template calls
+fix: Make it even harder to call `sql` incorrectly

--- a/.changeset/brown-dodos-sparkle.md
+++ b/.changeset/brown-dodos-sparkle.md
@@ -1,6 +1,0 @@
----
-'@vercel/postgres': minor
----
-
-feat: Allow `unsafeUnescaped` insertions into `sql` template calls
-fix: Make it even harder to call `sql` incorrectly

--- a/.changeset/tall-cameras-breathe.md
+++ b/.changeset/tall-cameras-breathe.md
@@ -1,0 +1,5 @@
+---
+'@vercel/postgres': minor
+---
+
+feat: Allow `unsafeUnescaped` insertions into `sql` template calls

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -31,9 +31,6 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Playwright tests on ${{ github.event.deployment_status.target_url }}
-        run: npx playwright test
+        run: pnpm integration-test
         env:
           PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.target_url }}
-
-      - name: Run Playwright tests in development mode
-        run: pnpm integration-test

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jest": "29.2.1",
     "lint-staged": "13.0.3",
     "prettier": "2.8.8",
+    "publint": "0.1.11",
     "ts-jest": "29.0.3",
     "turbo": "latest",
     "typescript": "^4.8.0"

--- a/packages/edge-config/package.json
+++ b/packages/edge-config/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint --max-warnings=0 .",
     "prepublishOnly": "pnpm run build",
     "prettier-check": "prettier --check .",
-    "publint": "npx publint --yes",
+    "publint": "npx publint",
     "test": "pnpm run test:node && pnpm run test:edge && pnpm run test:common",
     "test:common": "jest --env @edge-runtime/jest-environment .common.test.ts && jest --env node .common.test.ts",
     "test:edge": "jest --env @edge-runtime/jest-environment .edge.test.ts",

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -35,7 +35,7 @@
     "lint": "eslint --max-warnings=0 .",
     "prepublishOnly": "pnpm run build",
     "prettier-check": "prettier --check .",
-    "publint": "npx publint --yes",
+    "publint": "npx publint",
     "test": "jest --env @edge-runtime/jest-environment .test.ts && jest --env node .test.ts",
     "type-check": "tsc --noEmit"
   },

--- a/packages/postgres-kysely/package.json
+++ b/packages/postgres-kysely/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint \"**/*.ts\"",
     "prepublishOnly": "pnpm run build",
     "prettier-check": "prettier --check .",
-    "publint": "npx publint --yes",
+    "publint": "npx publint",
     "test": "jest --env @edge-runtime/jest-environment .test.ts && jest --env node .test.ts",
     "type-check": "tsc --noEmit"
   },

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -36,7 +36,7 @@ const client = createClient({
 
 ```typescript
 // no-config
-import { sql } from '@vercel/postgres';
+import { sql, unsafeUnescaped } from '@vercel/postgres';
 
 const id = 100;
 
@@ -49,6 +49,10 @@ const client = await sql.connect();
 const { rows } = await client.sql`SELECT * FROM users WHERE id = ${userId};`;
 await client.sql`UPDATE users SET status = 'satisfied' WHERE id = ${userId};`;
 client.release();
+
+// Unsafely parameterize any part of the query
+// Translates to: `await pg.query('SELECT * FROM users WHERE id = $1;', [userId]);`
+await sql`SELECT * FROM ${unsafeUnescaped('users')} WHERE id = ${userId};`;
 ```
 
 The `sql` import in the query above is just a modified `Pool` object (that's why you can call it). If you're running a custom config with `createPool`, the same functionality is available as `pool.sql`.

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run build",
     "prettier-check": "prettier --check .",
-    "publint": "npx publint --yes",
+    "publint": "npx publint",
     "test": "jest --env @edge-runtime/jest-environment .test.ts && jest --env node .test.ts",
     "type-check": "tsc --noEmit"
   },

--- a/packages/postgres/src/index.test.ts
+++ b/packages/postgres/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   postgresConnectionString,
   sql,
   db,
+  unsafeUnescaped,
 } from './index';
 
 describe('@vercel/postgres', () => {
@@ -21,5 +22,8 @@ describe('@vercel/postgres', () => {
   });
   it('exports a default db pool instance', () => {
     expect(typeof db).toEqual('function');
+  });
+  it('exports unsafeUnescaped', () => {
+    expect(typeof unsafeUnescaped).toEqual('function');
   });
 });

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -5,6 +5,7 @@ import type { Primitive } from './sql-template';
 export * from './create-client';
 export * from './create-pool';
 export * from './types';
+export { unsafeUnescaped } from './sql-template';
 export { postgresConnectionString } from './postgres-connection-string';
 
 let pool: VercelPool | undefined;

--- a/packages/postgres/src/sql-template.test.ts
+++ b/packages/postgres/src/sql-template.test.ts
@@ -1,7 +1,7 @@
 import { VercelPostgresError } from './error';
-import { sqlTemplate } from './sql-template';
+import { sqlTemplate, unsafeUnescaped } from './sql-template';
 
-const cases = [
+const validCases = [
   {
     input: sqlTemplate`SELECT * FROM users WHERE id = ${123}`,
     output: ['SELECT * FROM users WHERE id = $1', [123]],
@@ -24,14 +24,70 @@ const cases = [
 ];
 
 describe('sql', () => {
-  it.each(cases)('should return a query and params', ({ input, output }) => {
-    expect(input).toEqual(output);
-  });
-  it('throws when not used as a tagged literal', () => {
+  it.each(validCases)(
+    'should return a query and params',
+    ({ input, output }) => {
+      expect(input).toEqual(output);
+    },
+  );
+  it('throws when accidentally not used as a tagged literal', () => {
     const likes = 100;
     expect(() => {
       // @ts-expect-error - intentionally incorrect usage
       sqlTemplate(`SELECT * FROM posts WHERE likes > ${likes}`);
     }).toThrow(VercelPostgresError);
   });
+  it('throws when deliberately not used as a tagged literal to try to make us look dumb', () => {
+    const likes = 100;
+    expect(() => {
+      // @ts-expect-error - intentionally incorrect usage
+      sqlTemplate([`SELECT * FROM posts WHERE likes > ${likes}`]);
+    }).toThrow(VercelPostgresError);
+    expect(() => {
+      // @ts-expect-error - intentionally incorrect usage
+      sqlTemplate(`SELECT * FROM posts WHERE likes > ${likes}`, 123);
+    }).toThrow(VercelPostgresError);
+  });
+});
+
+const unescapedCases = [
+  {
+    input: sqlTemplate`SELECT * FROM ${unsafeUnescaped(
+      'users',
+    )} WHERE id = ${123}`,
+    output: ['SELECT * FROM users WHERE id = $1', [123]],
+  },
+  {
+    input: sqlTemplate`SELECT * ${unsafeUnescaped(
+      'FROM',
+    )} users WHERE id = ${123} AND name = ${'John'}`,
+    output: ['SELECT * FROM users WHERE id = $1 AND name = $2', [123, 'John']],
+  },
+  {
+    input: sqlTemplate`SELECT ${unsafeUnescaped(
+      '*',
+    )} FROM users WHERE name = ${'John; DROP TABLE users;--'}`,
+    output: [
+      'SELECT * FROM users WHERE name = $1',
+      ['John; DROP TABLE users;--'],
+    ],
+  },
+  {
+    input: sqlTemplate`SELECT * FROM users WHERE name = ${unsafeUnescaped(
+      "'John'; DROP TABLE users;--",
+    )}`,
+    output: [
+      "SELECT * FROM users WHERE name = 'John'; DROP TABLE users;--",
+      [],
+    ],
+  },
+];
+
+describe('unsafeUnescaped', () => {
+  it.each(unescapedCases)(
+    'should return a query with an unchanged value',
+    ({ input, output }) => {
+      expect(input).toEqual(output);
+    },
+  );
 });

--- a/packages/postgres/src/sql-template.ts
+++ b/packages/postgres/src/sql-template.ts
@@ -1,24 +1,93 @@
 import { VercelPostgresError } from './error';
 
-export type Primitive = string | number | boolean | undefined | null;
+export type Primitive =
+  | string
+  | number
+  | boolean
+  | undefined
+  | null
+  | UnsafeUnescaped;
+
+const unsafeUnescapedSecret = Symbol();
 
 export function sqlTemplate(
   strings: TemplateStringsArray,
   ...values: Primitive[]
 ): [string, Primitive[]] {
-  if (!Array.isArray(strings)) {
+  if (!isTemplateStringsArray(strings) || !Array.isArray(values)) {
     throw new VercelPostgresError(
       'incorrect_tagged_template_call',
       "It looks like you tried to call `sql` as a function. Make sure to use it as a tagged template.\n\tExample: sql`SELECT * FROM users`, not sql('SELECT * FROM users')",
     );
   }
 
-  // ts tries to annotate `strings` with `& any[]` because of the prior check which breaks the type
-  let result = (strings as TemplateStringsArray)[0] ?? '';
+  let result = strings[0] ?? '';
+  const params: Exclude<Primitive, UnsafeUnescaped>[] = [];
 
+  let offset = 0;
   for (let i = 1; i < strings.length; i++) {
-    result += `$${i}${(strings as TemplateStringsArray)[i] ?? ''}`;
+    const value = values[i - 1];
+    if (isUnsafeUnescaped(value)) {
+      result += `${value[unsafeUnescapedSecret]}${strings[i] ?? ''}`;
+      offset++;
+      continue;
+    }
+    params.push(value);
+    result += `$${i - offset}${strings[i] ?? ''}`;
   }
 
-  return [result, values];
+  return [result, params];
+}
+
+// We do this so that no possible value can be `UnsafeUnescaped` without running through the
+// `unsafeUnescaped` function. This is important because we don't want to accidentally allow
+// some random input to "pretend" to be `unsafeUnescaped`.
+interface UnsafeUnescaped {
+  [unsafeUnescapedSecret]: string;
+}
+
+/**
+ * During normal template string interpolation, values are replaced with pgsql parameters. For example,
+ * ```ts
+ * sql`SELECT * FROM users WHERE id = ${id}`;
+ * ```
+ * becomes
+ * ```ts
+ * pg.query('SELECT * FROM users WHERE id = $1', [id]);
+ * ```
+ *
+ * Sometimes, it's useful to be able to insert values into a query in places where pgsql parameters aren't allowed.
+ * For example, to parameterize a column or table name. To do this, you can use `unsafeUnescaped`:
+ * ```ts
+ * sql`SELECT * FROM ${unsafeUnescaped('users')} WHERE id = ${id}`;
+ * ```
+ * becomes
+ * ```ts
+ * pg.query('SELECT * FROM users WHERE id = $1', [id]);
+ * ```
+ *
+ * This is _unsafe_ and _will_ lead to SQL injection vulnerabilities if you do not sanitize your input.
+ *
+ * @param value The value to ignore during template string interpolation
+ * @returns A value that will be ignored during {@link sqlTemplate} template string interpolation
+ */
+export function unsafeUnescaped(value: string): UnsafeUnescaped {
+  return { [unsafeUnescapedSecret]: value };
+}
+
+function isTemplateStringsArray(
+  strings: unknown,
+): strings is TemplateStringsArray {
+  return (
+    // @ts-expect-error - I don't know how to convince TS that an array can have a property
+    Array.isArray(strings) && 'raw' in strings && Array.isArray(strings.raw)
+  );
+}
+
+function isUnsafeUnescaped(value: unknown): value is UnsafeUnescaped {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    unsafeUnescapedSecret in value
+  );
 }

--- a/packages/postgres/src/sql-template.ts
+++ b/packages/postgres/src/sql-template.ts
@@ -8,7 +8,7 @@ export type Primitive =
   | null
   | UnsafeUnescaped;
 
-const unsafeUnescapedSecret = Symbol();
+const unsafeUnescapedSecret = Symbol('The key for all unsafe unescaped values');
 
 export function sqlTemplate(
   strings: TemplateStringsArray,
@@ -68,7 +68,7 @@ interface UnsafeUnescaped {
  *
  * This is _unsafe_ and _will_ lead to SQL injection vulnerabilities if you do not sanitize your input.
  *
- * @param value The value to ignore during template string interpolation
+ * @param value - The value to ignore during template string interpolation
  * @returns A value that will be ignored during {@link sqlTemplate} template string interpolation
  */
 export function unsafeUnescaped(value: string): UnsafeUnescaped {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,16 +21,19 @@ importers:
         version: 8.0.1
       jest:
         specifier: 29.2.1
-        version: 29.2.1(@types/node@18.11.3)
+        version: 29.2.1
       lint-staged:
         specifier: 13.0.3
         version: 13.0.3
       prettier:
         specifier: 2.8.8
         version: 2.8.8
+      publint:
+        specifier: 0.1.11
+        version: 0.1.11
       ts-jest:
         specifier: 29.0.3
-        version: 29.0.3(@babel/core@7.19.6)(esbuild@0.15.18)(jest@29.2.1)(typescript@4.8.4)
+        version: 29.0.3(jest@29.2.1)(typescript@4.9.5)
       turbo:
         specifier: latest
         version: 1.9.3
@@ -2394,7 +2397,7 @@ packages:
       eslint: 8.25.0
       eslint-config-prettier: 8.8.0(eslint@8.25.0)
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.27.5)
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.38.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.1)(eslint-plugin-import@2.27.5)(eslint@8.25.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.25.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-typescript@3.5.5)(eslint@8.25.0)
       eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.59.1)(eslint@8.25.0)(jest@29.2.1)(typescript@4.9.5)
@@ -2786,6 +2789,12 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  /brace-expansion@2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.2
+    dev: true
 
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -3684,7 +3693,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-typescript@3.5.5)(eslint@8.38.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-typescript@3.5.5)(eslint@8.25.0)
 
   /eslint-import-resolver-node@0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
@@ -3706,6 +3715,29 @@ packages:
       enhanced-resolve: 5.13.0
       eslint: 8.38.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.38.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-typescript@3.5.5)(eslint@8.25.0)
+      get-tsconfig: 4.5.0
+      globby: 13.1.4
+      is-core-module: 2.12.0
+      is-glob: 4.0.3
+      synckit: 0.8.5
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-node
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.59.1)(eslint-plugin-import@2.27.5)(eslint@8.25.0):
+    resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      eslint-plugin-import: '*'
+    dependencies:
+      debug: 4.3.4
+      enhanced-resolve: 5.13.0
+      eslint: 8.25.0
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-typescript@3.5.5)(eslint@8.25.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-typescript@3.5.5)(eslint@8.25.0)
       get-tsconfig: 4.5.0
       globby: 13.1.4
@@ -3743,7 +3775,7 @@ packages:
       debug: 3.2.7
       eslint: 8.25.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.38.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.1)(eslint-plugin-import@2.27.5)(eslint@8.25.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3773,6 +3805,34 @@ packages:
       eslint: 8.38.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.38.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-typescript@3.5.5)(eslint@8.25.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.59.1(eslint@8.25.0)(typescript@4.9.5)
+      debug: 3.2.7
+      eslint: 8.25.0
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.1)(eslint-plugin-import@2.27.5)(eslint@8.25.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3871,6 +3931,7 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: false
 
   /eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.59.1)(eslint@8.25.0)(jest@29.2.1)(typescript@4.9.5):
     resolution: {integrity: sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==}
@@ -3888,7 +3949,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.59.1(@typescript-eslint/parser@5.59.1)(eslint@8.25.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 5.59.1(eslint@8.25.0)(typescript@4.9.5)
       eslint: 8.25.0
-      jest: 29.2.1(@types/node@18.11.3)
+      jest: 29.2.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4813,6 +4874,17 @@ packages:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  /glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.6
+      once: 1.4.0
+    dev: true
+
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
@@ -4938,6 +5010,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
+    dev: true
+
+  /ignore-walk@5.0.1:
+    resolution: {integrity: sha512-yemi4pMf51WKT7khInJqAvsIGzoqYXblnsz0ql8tM+yi1EKYTY1evX4NAbJrLL/Aanr2HyZeluqU+Oi7MGHokw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      minimatch: 5.1.6
     dev: true
 
   /ignore@5.2.4:
@@ -5273,6 +5352,34 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /jest-cli@29.5.0:
+    resolution: {integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.5.0
+      '@jest/test-result': 29.5.0
+      '@jest/types': 29.5.0
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      import-local: 3.1.0
+      jest-config: 29.5.0
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      prompts: 2.4.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    dev: true
+
   /jest-cli@29.5.0(@types/node@18.11.3):
     resolution: {integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5326,6 +5433,44 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
+    dev: true
+
+  /jest-config@29.5.0:
+    resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.21.0
+      '@jest/test-sequencer': 29.5.0
+      '@jest/types': 29.5.0
+      babel-jest: 29.5.0(@babel/core@7.21.0)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.5.0
+      jest-environment-node: 29.5.0
+      jest-get-type: 29.4.3
+      jest-regex-util: 29.4.3
+      jest-resolve: 29.5.0
+      jest-runner: 29.5.0
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.5.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /jest-config@29.5.0(@types/node@18.11.3):
@@ -5752,6 +5897,26 @@ packages:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
+  /jest@29.2.1:
+    resolution: {integrity: sha512-K0N+7rx+fv3Us3KhuwRSJt55MMpZPs9Q3WSO/spRZSnsalX8yEYOTQ1PiSN7OvqzoRX4JEUXCbOJRlP4n8m5LA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.5.0
+      '@jest/types': 29.5.0
+      import-local: 3.1.0
+      jest-cli: 29.5.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    dev: true
+
   /jest@29.2.1(@types/node@18.11.3):
     resolution: {integrity: sha512-K0N+7rx+fv3Us3KhuwRSJt55MMpZPs9Q3WSO/spRZSnsalX8yEYOTQ1PiSN7OvqzoRX4JEUXCbOJRlP4n8m5LA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -6104,6 +6269,13 @@ packages:
     dependencies:
       brace-expansion: 1.1.11
 
+  /minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
     engines: {node: '>= 6'}
@@ -6119,6 +6291,11 @@ packages:
   /mixme@0.5.9:
     resolution: {integrity: sha512-VC5fg6ySUscaWUpI4gxCBTQMH2RdUpNrk+MsbpCYtIvf9SBJdiUey4qE7BXviJsJR4nDQxCZ+3yaYNW3guz/Pw==}
     engines: {node: '>= 8.0.0'}
+    dev: true
+
+  /mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
     dev: true
 
   /ms@2.1.2:
@@ -6240,6 +6417,29 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
     dev: false
+
+  /npm-bundled@2.0.1:
+    resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      npm-normalize-package-bin: 2.0.0
+    dev: true
+
+  /npm-normalize-package-bin@2.0.0:
+    resolution: {integrity: sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dev: true
+
+  /npm-packlist@5.1.3:
+    resolution: {integrity: sha512-263/0NGrn32YFYi4J533qzrQ/krmmrWwhKkzwTuM4f/07ug51odoaNjUexxO4vxlzURHcmYMH1QjvHjsNDKLVg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      glob: 8.1.0
+      ignore-walk: 5.0.1
+      npm-bundled: 2.0.1
+      npm-normalize-package-bin: 2.0.0
+    dev: true
 
   /npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -6687,6 +6887,16 @@ packages:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
     dev: true
 
+  /publint@0.1.11:
+    resolution: {integrity: sha512-sD0rtIEadks83MkpomJswBO/YHExJLkta1TyqUhb0/aVV+o3ZlVnwsDPjCAow8tpfxmLGutCSLWq32yfhPB98w==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      npm-packlist: 5.1.3
+      picocolors: 1.0.0
+      sade: 1.8.1
+    dev: true
+
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
@@ -6891,6 +7101,13 @@ packages:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
       tslib: 2.5.0
+    dev: true
+
+  /sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
     dev: true
 
   /safe-regex-test@1.0.0:
@@ -7424,6 +7641,39 @@ packages:
       make-error: 1.3.6
       semver: 7.5.0
       typescript: 4.8.4
+      yargs-parser: 21.1.1
+    dev: true
+
+  /ts-jest@29.0.3(jest@29.2.1)(typescript@4.9.5):
+    resolution: {integrity: sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.2.1
+      jest-util: 29.5.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.0
+      typescript: 4.9.5
       yargs-parser: 21.1.1
     dev: true
 


### PR DESCRIPTION
Needs an audit from security folks!

Adds an API for unsafely injecting values into the `sql` template:

```ts
import { sql, unsafeUnescaped } from '@vercel/postgres';

await sql`SELECT * FROM ${unsafeUnescaped('users')} WHERE id = 1;`;
```

_Do not_ un-draft this PR. It's an experimental feature we're trying out internally and it may never see the light of day.