### PR TITLE
feat: Querybuilder API

### DIFF
--- a/.changeset/healthy-zebras-dress.md
+++ b/.changeset/healthy-zebras-dress.md
@@ -1,0 +1,5 @@
+---
+'@vercel/postgres': minor
+---
+
+breaking: Make `sql` a builder, requires `.execute()` to send query to db

--- a/packages/postgres/src/create-client.ts
+++ b/packages/postgres/src/create-client.ts
@@ -6,7 +6,8 @@ import {
   postgresConnectionString,
 } from './postgres-connection-string';
 import { VercelPostgresError } from './error';
-import { Primitive, SqlTemplate } from './sql-template';
+import type { Primitive } from './sql-template';
+import { SqlTemplate } from './sql-template';
 
 export class VercelClient extends Client {
   /**

--- a/packages/postgres/src/create-client.ts
+++ b/packages/postgres/src/create-client.ts
@@ -1,4 +1,4 @@
-import type { QueryResult, QueryResultRow } from '@neondatabase/serverless';
+import type { QueryResultRow } from '@neondatabase/serverless';
 import { Client } from '@neondatabase/serverless';
 import type { VercelPostgresClientConfig } from './types';
 import {
@@ -6,8 +6,7 @@ import {
   postgresConnectionString,
 } from './postgres-connection-string';
 import { VercelPostgresError } from './error';
-import type { Primitive } from './sql-template';
-import { sqlTemplate } from './sql-template';
+import { Primitive, SqlTemplate } from './sql-template';
 
 export class VercelClient extends Client {
   /**
@@ -19,18 +18,19 @@ export class VercelClient extends Client {
    * const pool = createClient();
    * const userId = 123;
    * await client.connect();
-   * const result = await pool.sql`SELECT * FROM users WHERE id = ${userId}`;
+   * const result = await pool.sql`SELECT * FROM users WHERE id = ${userId}`.execute();
    * // Equivalent to: await pool.query('SELECT * FROM users WHERE id = $1', [id]);
    * await client.end();
    * ```
    * @returns A promise that resolves to the query result.
    */
-  async sql<O extends QueryResultRow>(
+  sql<O extends QueryResultRow>(
     strings: TemplateStringsArray,
     ...values: Primitive[]
-  ): Promise<QueryResult<O>> {
-    const [query, params] = sqlTemplate(strings, ...values);
-    return this.query(query, params);
+  ): SqlTemplate<O> {
+    const template = new SqlTemplate<O>(this.query.bind(this));
+    template.append(strings, ...values);
+    return template;
   }
 }
 

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -1,6 +1,6 @@
-import type { QueryResult, QueryResultRow } from '@neondatabase/serverless';
+import type { QueryResultRow } from '@neondatabase/serverless';
 import { type VercelPool, createPool } from './create-pool';
-import type { Primitive } from './sql-template';
+import type { Primitive, SqlTemplate } from './sql-template';
 
 export * from './create-client';
 export * from './create-pool';
@@ -9,10 +9,45 @@ export { postgresConnectionString } from './postgres-connection-string';
 
 let pool: VercelPool | undefined;
 
+type DefaultPoolExport = VercelPool &
+  (<O extends QueryResultRow>(
+    strings: TemplateStringsArray,
+    ...values: Primitive[]
+  ) => SqlTemplate<O>);
+
 // for future peons who aren't briliant like Malte, this means
 // "make an object that will pretend to be a pool but not initialize itself
 // until someone tries to access a property on it"
 // this also makes it callable, so you can call `sql` as a function
+/**
+ * A template literal tag providing safe, easy to use SQL parameterization.
+ * Almost the same as a pool created via {@link createPool}, but with the ability to be called
+ * as a function for convenient one-off querying.
+ *
+ * @example
+ * For a one-off query:
+ * ```ts
+ * const userId = 123;
+ * const result = await sql`SELECT * FROM users WHERE id = ${userId}`.execute();
+ * // Equivalent to: await pool.query('SELECT * FROM users WHERE id = $1', [id]);
+ * ```
+ *
+ * @example
+ * For multiple queries during the same request, or to use a transaction:
+ * ```ts
+ * const client = await sql.connect();
+ * const { rows } = await client.sql`SELECT * FROM users WHERE id = ${userId};`.execute();
+ * await client.sql`UPDATE users SET status = 'satisfied' WHERE id = ${userId};`.execute();
+ * client.release();
+ * ```
+ *
+ * @example
+ * To unsafely parameterize things that pgsql can't natively parameterize:
+ * ```ts
+ * // Don't use `appendUnsafeRaw` unless you absolutely know the input to it is safe!
+ * const result = await sql`SELECT * FROM `.appendUnsafeRaw('users').append` WHERE id = 1;`.execute();
+ * ```
+ */
 export const sql = new Proxy(
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   () => {},
@@ -39,10 +74,35 @@ export const sql = new Proxy(
       return pool.sql(...argumentsList);
     },
   },
-) as unknown as VercelPool &
-  (<O extends QueryResultRow>(
-    strings: TemplateStringsArray,
-    ...values: Primitive[]
-  ) => Promise<QueryResult<O>>);
+) as unknown as DefaultPoolExport;
 
+/**
+ * A template literal tag providing safe, easy to use SQL parameterization.
+ * Almost the same as a pool created via {@link createPool}, but with the ability to be called
+ * as a function for convenient one-off querying.
+ *
+ * @example
+ * For a one-off query:
+ * ```ts
+ * const userId = 123;
+ * const result = await sql`SELECT * FROM users WHERE id = ${userId}`.execute();
+ * // Equivalent to: await pool.query('SELECT * FROM users WHERE id = $1', [id]);
+ * ```
+ *
+ * @example
+ * For multiple queries during the same request, or to use a transaction:
+ * ```ts
+ * const client = await sql.connect();
+ * const { rows } = await client.sql`SELECT * FROM users WHERE id = ${userId};`.execute();
+ * await client.sql`UPDATE users SET status = 'satisfied' WHERE id = ${userId};`.execute();
+ * client.release();
+ * ```
+ *
+ * @example
+ * To unsafely parameterize things that pgsql can't natively parameterize:
+ * ```ts
+ * // Don't use `appendUnsafeRaw` unless you absolutely know the input to it is safe!
+ * const result = await sql`SELECT * FROM `.appendUnsafeRaw('users').append` WHERE id = 1;`.execute();
+ * ```
+ */
 export const db = sql;

--- a/packages/postgres/src/sql-template.test.ts
+++ b/packages/postgres/src/sql-template.test.ts
@@ -1,6 +1,7 @@
-import { QueryResult, QueryResultRow } from '@neondatabase/serverless';
+import type { QueryResult, QueryResultRow } from '@neondatabase/serverless';
 import { VercelPostgresError } from './error';
-import { Primitive, SqlTemplate } from './sql-template';
+import type { Primitive } from './sql-template';
+import { SqlTemplate } from './sql-template';
 
 // this is just a mock that causes `execute` to return the internal state of the SqlTemplate
 const returnBuiltDbQuery = jest.fn(
@@ -37,11 +38,11 @@ const validCases = [
   },
 ];
 
-beforeEach(() => {
-  returnBuiltDbQuery.mockClear();
-});
-
 describe('append', () => {
+  beforeEach(() => {
+    returnBuiltDbQuery.mockClear();
+  });
+
   it.each(validCases)(
     'should return a query and params',
     async ({ input, output }) => {

--- a/packages/postgres/src/sql-template.test.ts
+++ b/packages/postgres/src/sql-template.test.ts
@@ -1,51 +1,79 @@
+import { QueryResult, QueryResultRow } from '@neondatabase/serverless';
 import { VercelPostgresError } from './error';
-import { sqlTemplate } from './sql-template';
+import { Primitive, SqlTemplate } from './sql-template';
+
+// this is just a mock that causes `execute` to return the internal state of the SqlTemplate
+const returnBuiltDbQuery = jest.fn(
+  <O extends QueryResultRow>(
+    query: string,
+    params?: Primitive[],
+  ): Promise<QueryResult<O>> =>
+    Promise.resolve([query, params] as unknown as QueryResult<O>),
+);
 
 const validCases = [
   {
-    input: sqlTemplate`SELECT * FROM users WHERE id = ${123}`,
+    input: new SqlTemplate(returnBuiltDbQuery)
+      .append`SELECT * FROM users WHERE id = ${123}`,
     output: ['SELECT * FROM users WHERE id = $1', [123]],
   },
   {
-    input: sqlTemplate`SELECT * FROM users WHERE id = ${123} AND name = ${'John'}`,
+    input: new SqlTemplate(returnBuiltDbQuery)
+      .append`SELECT * FROM users WHERE id = ${123} AND name = ${'John'}`,
     output: ['SELECT * FROM users WHERE id = $1 AND name = $2', [123, 'John']],
   },
   {
-    input: sqlTemplate`SELECT * FROM users WHERE name = ${'John; DROP TABLE users;--'}`,
+    input: new SqlTemplate(returnBuiltDbQuery).append`SELECT *`
+      .append` FROM users WHERE name = ${'John; DROP TABLE users;--'}`,
     output: [
       'SELECT * FROM users WHERE name = $1',
       ['John; DROP TABLE users;--'],
     ],
   },
   {
-    input: sqlTemplate`SELECT * FROM users WHERE name = ${'John AND 1=1'}`,
+    input: new SqlTemplate(returnBuiltDbQuery).append`SELECT * FROM users`
+      .append` WHERE name = ${'John AND 1=1'}`,
     output: ['SELECT * FROM users WHERE name = $1', ['John AND 1=1']],
   },
 ];
 
-describe('sql', () => {
+beforeEach(() => {
+  returnBuiltDbQuery.mockClear();
+});
+
+describe('append', () => {
   it.each(validCases)(
     'should return a query and params',
-    ({ input, output }) => {
-      expect(input).toEqual(output);
+    async ({ input, output }) => {
+      const built = input.build();
+      expect(built).toEqual(output);
+      await input.execute();
+      expect(returnBuiltDbQuery).toHaveBeenCalledWith(...built);
     },
   );
   it('throws when accidentally not used as a tagged literal', () => {
     const likes = 100;
     expect(() => {
-      // @ts-expect-error - intentionally incorrect usage
-      sqlTemplate(`SELECT * FROM posts WHERE likes > ${likes}`);
+      new SqlTemplate(returnBuiltDbQuery).append(
+        // @ts-expect-error - intentionally incorrect usage
+        `SELECT * FROM posts WHERE likes > ${likes}`,
+      );
     }).toThrow(VercelPostgresError);
   });
   it('throws when deliberately not used as a tagged literal to try to make us look dumb', () => {
     const likes = 100;
     expect(() => {
       // @ts-expect-error - intentionally incorrect usage
-      sqlTemplate([`SELECT * FROM posts WHERE likes > ${likes}`]);
+      new SqlTemplate(returnBuiltDbQuery).append([
+        `SELECT * FROM posts WHERE likes > ${likes}`,
+      ]);
     }).toThrow(VercelPostgresError);
     expect(() => {
-      // @ts-expect-error - intentionally incorrect usage
-      sqlTemplate(`SELECT * FROM posts WHERE likes > ${likes}`, 123);
+      new SqlTemplate(returnBuiltDbQuery).append(
+        // @ts-expect-error - intentionally incorrect usage
+        `SELECT * FROM posts WHERE likes > ${likes}`,
+        123,
+      );
     }).toThrow(VercelPostgresError);
   });
 });

--- a/packages/postgres/src/sql-template.ts
+++ b/packages/postgres/src/sql-template.ts
@@ -1,32 +1,120 @@
+import type { QueryResult, QueryResultRow } from '@neondatabase/serverless';
 import { VercelPostgresError } from './error';
 
-export type Primitive = string | number | boolean | undefined | null;
+/**
+ * Allows safe construction and execution of SQL queries using tagged templates.
+ */
+export class SqlTemplate<O extends QueryResultRow> {
+  private templates: {
+    strings: TemplateStringsArray;
+    params: Primitive[];
+  }[] = [];
 
-export function sqlTemplate(
-  strings: TemplateStringsArray,
-  ...values: Primitive[]
-): [string, Primitive[]] {
-  if (!isTemplateStringsArray(strings) || !Array.isArray(values)) {
-    throw new VercelPostgresError(
-      'incorrect_tagged_template_call',
-      "It looks like you tried to call `sql` as a function. Make sure to use it as a tagged template.\n\tExample: sql`SELECT * FROM users`, not sql('SELECT * FROM users')",
+  constructor(
+    private dbQuery: (
+      query: string,
+      params?: Primitive[],
+    ) => Promise<QueryResult<O>>,
+  ) {}
+
+  /**
+   * Appends SQL code to the end of this template.
+   * @example
+   * ```ts
+   * template.append`SELECT * FROM pokemon`;
+   * if (pokemonName) {
+   *   template.append` WHERE name = ${pokemonName}`;
+   * }
+   * const { rows, fields } = await template.execute();
+   * ```
+   * @returns This template, with the templated SQL appended.
+   */
+  public append(strings: TemplateStringsArray, ...values: Primitive[]): this {
+    SqlTemplate.throwIfNotTemplateStringsArray(strings);
+    SqlTemplate.throwIfNotValuesArray(values);
+    this.templates.push({ strings, params: values });
+    return this;
+  }
+
+  /**
+   * Appends raw, unsafe SQL code to the end of this template. Do not use
+   * unless you are absolutely sure that the SQL is safe.
+   * @example
+   * ```ts
+   * template.append`SELECT * FROM`.appendUnsafeRaw(' pokemon');
+   * if (pokemonName) {
+   *   template.append` WHERE name = ${pokemonName}`;
+   * }
+   * const { rows, fields } = await template.execute();
+   * ```
+   * @returns This template, with the unsafe raw SQL appended.
+   */
+  public appendUnsafeRaw(value: string): this {
+    const fakeTemplateString = [value] as unknown as string[] & {
+      raw: string[];
+    };
+    fakeTemplateString.raw = [value];
+    this.templates.push({ strings: fakeTemplateString, params: [] });
+    return this;
+  }
+
+  /**
+   * Execute this query against the database, returning the result.
+   * @returns A promise that resolves to the query result.
+   */
+  public async execute(): Promise<QueryResult<O>> {
+    return this.dbQuery(...this.build());
+  }
+
+  /**
+   * Build this template into a query string and parameter array.
+   * @returns A tuple containing the query string and parameter array.
+   */
+  public build(): [string, Primitive[]] {
+    let query = '';
+    const aggregatedParams: Primitive[] = [];
+
+    for (const { strings, params } of this.templates) {
+      query += strings[0] ?? '';
+      for (let i = 1; i < strings.length; i++) {
+        aggregatedParams.push(params[i - 1]);
+        query += `$${aggregatedParams.length}${strings[i] ?? ''}`;
+      }
+    }
+
+    return [query, aggregatedParams];
+  }
+
+  private static isTemplateStringsArray(
+    strings: unknown,
+  ): strings is TemplateStringsArray {
+    return (
+      // @ts-expect-error - I don't know how to convince TS that an array can have a property
+      Array.isArray(strings) && 'raw' in strings && Array.isArray(strings.raw)
     );
   }
 
-  let result = strings[0] ?? '';
-
-  for (let i = 1; i < strings.length; i++) {
-    result += `$${i}${strings[i] ?? ''}`;
+  private static throwIfNotTemplateStringsArray(
+    strings: unknown,
+  ): asserts strings is TemplateStringsArray {
+    if (!SqlTemplate.isTemplateStringsArray(strings)) {
+      throw new VercelPostgresError(
+        'incorrect_tagged_template_call',
+        "It looks like you tried to call `sql` or `append` as a function. Make sure to use it as a tagged template.\n\tExample: sql`SELECT * FROM users`, not sql('SELECT * FROM users')",
+      );
+    }
   }
 
-  return [result, values];
+  private static throwIfNotValuesArray(
+    values: unknown,
+  ): asserts values is Primitive[] {
+    if (!Array.isArray(values)) {
+      throw new VercelPostgresError(
+        'incorrect_tagged_template_call',
+        "It looks like you tried to call `sql` or `append` as a function. Make sure to use it as a tagged template.\n\tExample: sql`SELECT * FROM users`, not sql('SELECT * FROM users')",
+      );
+    }
+  }
 }
 
-function isTemplateStringsArray(
-  strings: unknown,
-): strings is TemplateStringsArray {
-  return (
-    // @ts-expect-error - I don't know how to convince TS that an array can have a property
-    Array.isArray(strings) && 'raw' in strings && Array.isArray(strings.raw)
-  );
-}
+export type Primitive = string | number | boolean | undefined | null;

--- a/test/next/src/lib/postgres-client.ts
+++ b/test/next/src/lib/postgres-client.ts
@@ -2,8 +2,8 @@ import type { QueryResult } from '@vercel/postgres';
 import { createClient } from '@vercel/postgres';
 
 export const queryUsers = async (): Promise<QueryResult> => {
-  const db = createClient();
-  await db.connect();
+  const client = createClient();
+  await client.connect();
   const timeoutPromise = new Promise<never>((_, reject) =>
     // eslint-disable-next-line no-promise-executor-return
     setTimeout(
@@ -11,10 +11,10 @@ export const queryUsers = async (): Promise<QueryResult> => {
       20000,
     ),
   );
-  const usersPromise = db.query('SELECT * FROM users');
+  const usersPromise = client.sql`SELECT * FROM users`.execute();
   try {
     return await Promise.race([timeoutPromise, usersPromise]);
   } finally {
-    await db.end();
+    await client.end();
   }
 };

--- a/test/next/src/lib/postgres-pool.ts
+++ b/test/next/src/lib/postgres-pool.ts
@@ -9,11 +9,6 @@ export const queryUsers = async (): Promise<QueryResult> => {
       20000,
     ),
   );
-  const client = await sql.connect();
-  const usersPromise = client.sql`SELECT * FROM users`;
-  try {
-    return await Promise.race([timeoutPromise, usersPromise]);
-  } finally {
-    client.release();
-  }
+  const usersPromise = sql`SELECT * FROM users`.execute();
+  return Promise.race([timeoutPromise, usersPromise]);
 };


### PR DESCRIPTION
BREAKING: This adds some functionality to our `sql` API. Prior to this PR, parameterization was limited to places that `pgsql` could accept parameters:

```ts
await sql`SELECT * FROM pokemon WHERE type = ${type};`; // WORKS
await sql`SELECT * FROM ${'pokemon'} WHERE type = ${type};`; // DOES NOT WORK
```

This adds a _very_ simple querybuilder API that allows unsafe, clearly-marked parameterization along with the ability to conditionally append clauses:

```ts
await sql`SELECT * FROM `.appendUnsafeRaw('users').append` WHERE type = ${type};`.execute();
// equivalent to:
await pool.query('SELECT * FROM users WHERE type = $1;', [type]);

// conditionally add clauses, _safely_:
const { type, weight, color } = filters;
const needsWhere = type || weight || color;

const query = sql`SELECT * FROM pokemon`;
if (needsWhere) {
  query.append` WHERE 1=1`;
  if (type) query.append` AND type = ${type}`;
  if (weight) query.append` AND weight = ${weight}`;
  if (color) query.append` AND color = ${color}`;
}
const { rows } = await query.execute();
// equivalent to something like the following (depending on conditions):
const { rows } = await pool.query('SELECT * FROM pokemon WHERE 1=1 AND type = $1 AND weight = $2', [type, weight]);
```

The only breaking change this adds is that calls to `sql` now require a `.execute()` to actually send the query to the database. 