### PR TITLE
test(GH): activate live tests

### DIFF
--- a/.github/workflows/integration-tests-dev.yml
+++ b/.github/workflows/integration-tests-dev.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: cache-playwright-linux-3
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -52,7 +52,7 @@ jobs:
         id: waitForVercelPreview
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 60
+          max_timeout: 600
 
       - name: Run Playwright tests on ${{ steps.waitForVercelPreview.outputs.url }}
         run: pnpm integration-test

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: cache-playwright-linux-3
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -17,7 +17,6 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    if: github.event.deployment_status.state == 'success'
     steps:
       - uses: actions/checkout@v3
 

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+      "outputs": ["dist/**"]
     },
     "lint": {
       "dependsOn": ["^build", "build"]


### PR DESCRIPTION
Previously these tests were triggered via a deployment_status but this is not compatible with github action cache (seen in https://github.com/actions/cache/issues/319).