### PR TITLE
chore(ci): fix playwright caching

### DIFF
--- a/.github/workflows/integration-tests-dev.yml
+++ b/.github/workflows/integration-tests-dev.yml
@@ -38,9 +38,6 @@ jobs:
         run: pnpm install
 
       - run: pnpm dlx playwright install --with-deps
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-      - run: pnpm dlx playwright install-deps
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       - name: Run Playwright tests in development mode
         run: pnpm integration-test

--- a/.github/workflows/integration-tests-dev.yml
+++ b/.github/workflows/integration-tests-dev.yml
@@ -27,8 +27,7 @@ jobs:
           node-version: '18'
           cache: 'pnpm'
 
-      - name: Cache playwright binaries
-        uses: actions/cache@v3
+      - uses: actions/cache@v3
         id: playwright-cache
         with:
           path: |

--- a/.github/workflows/integration-tests-dev.yml
+++ b/.github/workflows/integration-tests-dev.yml
@@ -27,24 +27,24 @@ jobs:
           node-version: '18'
           cache: 'pnpm'
 
-      - name: Install dependencies
-        run: pnpm install
-
-      # from https://dev.to/jpoehnelt/caching-playwright-binaries-in-github-actions-2mfc
-      - uses: actions/cache@v2
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
         id: playwright-cache
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Install dependencies
         run: pnpm install
 
-      - run: pnpm dlx playwright install --with-deps
+      - run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-      - run: pnpm dlx playwright install-deps
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+      - run: npx playwright install-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       - name: Run Playwright tests in development mode
         run: pnpm integration-test

--- a/.github/workflows/integration-tests-dev.yml
+++ b/.github/workflows/integration-tests-dev.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - run: npx playwright install --with-deps
+      - run: pnpm dlx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-      - run: npx playwright install-deps
+      - run: pnpm dlx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       - name: Run Playwright tests in development mode

--- a/.github/workflows/integration-tests-dev.yml
+++ b/.github/workflows/integration-tests-dev.yml
@@ -27,9 +27,6 @@ jobs:
           node-version: '18'
           cache: 'pnpm'
 
-      - name: Get installed Playwright version
-        id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
       - name: Cache playwright binaries
         uses: actions/cache@v3
         id: playwright-cache

--- a/.github/workflows/integration-tests-dev.yml
+++ b/.github/workflows/integration-tests-dev.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # This will use the cache for browsers. But it will reinstall system deps, which can't be cached
+      # https://github.com/microsoft/playwright/issues/20603#issuecomment-1416243810
       - run: pnpm dlx playwright install --with-deps
 
       - name: Run Playwright tests in development mode

--- a/.github/workflows/integration-tests-dev.yml
+++ b/.github/workflows/integration-tests-dev.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - run: npx playwright install --with-deps
+      - run: pnpm dlx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-      - run: npx playwright install-deps
+      - run: pnpm dlx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       # https://github.com/patrickedqvist/wait-for-vercel-preview

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # This will use the cache for browsers. But it will reinstall system deps, which can't be cached
+      # https://github.com/microsoft/playwright/issues/20603#issuecomment-1416243810
       - run: pnpm dlx playwright install --with-deps
 
       # https://github.com/patrickedqvist/wait-for-vercel-preview

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -28,9 +28,6 @@ jobs:
           node-version: '18'
           cache: 'pnpm'
 
-      - name: Get installed Playwright version
-        id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
       - name: Cache playwright binaries
         uses: actions/cache@v3
         id: playwright-cache

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -28,8 +28,7 @@ jobs:
           node-version: '18'
           cache: 'pnpm'
 
-      - name: Cache playwright binaries
-        uses: actions/cache@v3
+      - uses: actions/cache@v3
         id: playwright-cache
         with:
           path: |

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -28,21 +28,24 @@ jobs:
           node-version: '18'
           cache: 'pnpm'
 
-      # from https://dev.to/jpoehnelt/caching-playwright-binaries-in-github-actions-2mfc
-      - uses: actions/cache@v2
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
         id: playwright-cache
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Install dependencies
         run: pnpm install
 
-      - run: pnpm dlx playwright install --with-deps
+      - run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-      - run: pnpm dlx playwright install-deps
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+      - run: npx playwright install-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       # https://github.com/patrickedqvist/wait-for-vercel-preview
       # this allows to use action cache, which is not possible when using deployment_status otherwise

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -39,9 +39,6 @@ jobs:
         run: pnpm install
 
       - run: pnpm dlx playwright install --with-deps
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-      - run: pnpm dlx playwright install-deps
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       # https://github.com/patrickedqvist/wait-for-vercel-preview
       # this allows to use action cache, which is not possible when using deployment_status otherwise


### PR DESCRIPTION
- Before this commit we were trying to be too smart for nothing: browser will be taken from cache by default if we cached them last time.
- OS dependencies can't be cached.
- there was an extra pnpm install
