### PR TITLE
feat: Change `KV_URL` to `KV_REST_API_URL`

### DIFF
--- a/packages/kv/README.md
+++ b/packages/kv/README.md
@@ -104,12 +104,12 @@ export default defineConfig(({ mode }) => {
 
 ```diff
 import { createClient } from '@vercel/kv';
-+ import { KV_URL, KV_REST_API_TOKEN } from '$env/static/private';
++ import { KV_REST_API_URL, KV_REST_API_TOKEN } from '$env/static/private';
 
 const kv = createClient({
 -  url: 'https://<hostname>.redis.vercel-storage.com',
 -  token: '<token>',
-+  url: KV_URL,
++  url: KV_REST_API_URL,
 +  token: KV_REST_API_TOKEN,
 });
 


### PR DESCRIPTION
We can't use `KV_URL` because it returns a Redis connection string, so we need to use `KV_REST_API_URL`, which gives the https connection string.