### PR TITLE
exit prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "canary",
   "initialVersions": {
     "@vercel/blob": "0.8.3",


### PR DESCRIPTION
Entered prerelease mode to test out `@vercel/edge-config`, and it worked so we can exit it now.

There's something else I want to test while in prerelease mode but I already prepared this PR to exit it later.