### PR TITLE
support third-party connection strings

### DIFF
--- a/.changeset/rude-carrots-dream.md
+++ b/.changeset/rude-carrots-dream.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': minor
+---
+
+support third-party connection strings

--- a/packages/edge-config/src/index.common.test.ts
+++ b/packages/edge-config/src/index.common.test.ts
@@ -178,3 +178,40 @@ describe('etags and if-none-match', () => {
     });
   });
 });
+
+describe('connectionStrings', () => {
+  describe('when used with external connection strings', () => {
+    const modifiedConnectionString = 'https://example.com/ecfg-2?token=token-2';
+
+    let edgeConfig: EdgeConfigClient;
+
+    beforeEach(() => {
+      fetchMock.resetMocks();
+      cache.clear();
+      edgeConfig = pkg.createClient(modifiedConnectionString);
+    });
+
+    it('should be a function', () => {
+      expect(typeof pkg.createClient).toBe('function');
+    });
+
+    describe('get', () => {
+      describe('when item exists', () => {
+        it('should fetch using information from the passed token', async () => {
+          fetchMock.mockResponse(JSON.stringify('bar'));
+
+          await expect(edgeConfig.get('foo')).resolves.toEqual('bar');
+
+          expect(fetchMock).toHaveBeenCalledTimes(1);
+          expect(fetchMock).toHaveBeenCalledWith(
+            `https://example.com/ecfg-2/item/foo?version=1`,
+            {
+              headers: new Headers({ Authorization: 'Bearer token-2' }),
+              cache: 'no-store',
+            },
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -301,7 +301,7 @@ export function createClient(
         return Promise.resolve(localEdgeConfig.digest);
       }
 
-      return fetchWithCachedResponse(`${baseUrl}/digest?version=1`, {
+      return fetchWithCachedResponse(`${baseUrl}/digest?version=${version}`, {
         headers: new Headers(headers),
         cache: 'no-store',
       }).then(


### PR DESCRIPTION
Supports external connection strings, except for just ones pointed to `edge-config.vercel.com`.

We keep supporting `edge-config.vercel.com` as the main way to connect to Edge Configs, and as the only way we optimize. But we now also support having external connection strings. 

The reason we support external connection strings is that it makes testing
edge config really straightforward. Users can provide  connection strings
pointing to their own servers and then either have a custom server
return the desired values or even intercept requests with something like
msw.

To allow interception we need a custom connection string as the
edge-config.vercel.com connection string might not always go over
the network, so msw would not have a chance to intercept.