### PR TITLE
Fix issue with Rollup and Vite

### DIFF
--- a/.changeset/metal-rabbits-work.md
+++ b/.changeset/metal-rabbits-work.md
@@ -1,0 +1,5 @@
+---
+"@vercel/kv": patch
+---
+
+Fix issue with Rollup and Vite

--- a/packages/kv/src/index.ts
+++ b/packages/kv/src/index.ts
@@ -120,15 +120,15 @@ export const kv = new Proxy(
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     get(target, prop) {
       if (!_kv) {
-        if (!process.env.KV_REST_API_URL || !process.env.KV_REST_API_TOKEN) {
+        if (!process.env['KV_REST_API_URL'] || !process.env['KV_REST_API_TOKEN']) {
           throw new Error(
             '@vercel/kv: Missing required environment variables KV_REST_API_URL and KV_REST_API_TOKEN',
           );
         }
 
         _kv = createClient({
-          url: process.env.KV_REST_API_URL,
-          token: process.env.KV_REST_API_TOKEN,
+          url: process.env['KV_REST_API_URL'],
+          token: process.env['KV_REST_API_TOKEN'],
         });
       }
 


### PR DESCRIPTION
Fixes #168.

It seems many tools like Vite and Rollup will remove `process.env` calls, unless the string version is used instead.