### PR TITLE
[edge-config] Add env and SDK version header to requests

### DIFF
--- a/.changeset/rare-planes-wink.md
+++ b/.changeset/rare-planes-wink.md
@@ -2,4 +2,4 @@
 '@vercel/edge-config': patch
 ---
 
-Add `x-node-env` header to requests
+Add `x-edge-config-vercel-env` header to requests

--- a/.changeset/rare-planes-wink.md
+++ b/.changeset/rare-planes-wink.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': patch
+---
+
+Add `x-node-env` header to requests

--- a/.changeset/rare-planes-wink.md
+++ b/.changeset/rare-planes-wink.md
@@ -2,4 +2,4 @@
 '@vercel/edge-config': patch
 ---
 
-Add `x-edge-config-vercel-env` header to requests
+Add `x-edge-config-vercel-env` and `x-edge-config-sdk` headers to requests

--- a/packages/edge-config/jest/setup.js
+++ b/packages/edge-config/jest/setup.js
@@ -1,3 +1,4 @@
 require('jest-fetch-mock').enableMocks();
 
 process.env.EDGE_CONFIG = 'https://edge-config.vercel.com/ecfg-1?token=token-1';
+process.env.VERCEL_ENV = 'test';

--- a/packages/edge-config/src/index.common.test.ts
+++ b/packages/edge-config/src/index.common.test.ts
@@ -80,7 +80,7 @@ describe('when running without lambda layer or via edge function', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-2',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -103,7 +103,7 @@ describe('when running without lambda layer or via edge function', () => {
             method: 'HEAD',
             headers: new Headers({
               Authorization: 'Bearer token-2',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -125,7 +125,7 @@ describe('when running without lambda layer or via edge function', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-2',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -172,7 +172,7 @@ describe('etags and if-none-match', () => {
         {
           headers: new Headers({
             Authorization: 'Bearer token-2',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         },
@@ -182,7 +182,7 @@ describe('etags and if-none-match', () => {
         {
           headers: new Headers({
             Authorization: 'Bearer token-2',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
             'if-none-match': 'a',
           }),
           cache: 'no-store',
@@ -221,7 +221,7 @@ describe('connectionStrings', () => {
             {
               headers: new Headers({
                 Authorization: 'Bearer token-2',
-                'x-node-env': 'test',
+                'x-edge-config-vercel-env': 'test',
               }),
               cache: 'no-store',
             },

--- a/packages/edge-config/src/index.common.test.ts
+++ b/packages/edge-config/src/index.common.test.ts
@@ -78,7 +78,10 @@ describe('when running without lambda layer or via edge function', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${modifiedBaseUrl}/item/foo?version=1`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-2' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-2',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -98,7 +101,10 @@ describe('when running without lambda layer or via edge function', () => {
           `${modifiedBaseUrl}/item/foo?version=1`,
           {
             method: 'HEAD',
-            headers: new Headers({ Authorization: 'Bearer token-2' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-2',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -117,7 +123,10 @@ describe('when running without lambda layer or via edge function', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${modifiedBaseUrl}/digest?version=1`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-2' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-2',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -161,7 +170,10 @@ describe('etags and if-none-match', () => {
       expect(fetchMock).toHaveBeenCalledWith(
         `${modifiedBaseUrl}/item/foo?version=1`,
         {
-          headers: new Headers({ Authorization: 'Bearer token-2' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-2',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         },
       );
@@ -170,6 +182,7 @@ describe('etags and if-none-match', () => {
         {
           headers: new Headers({
             Authorization: 'Bearer token-2',
+            'x-node-env': 'test',
             'if-none-match': 'a',
           }),
           cache: 'no-store',
@@ -206,7 +219,10 @@ describe('connectionStrings', () => {
           expect(fetchMock).toHaveBeenCalledWith(
             `https://example.com/ecfg-2/item/foo?version=1`,
             {
-              headers: new Headers({ Authorization: 'Bearer token-2' }),
+              headers: new Headers({
+                Authorization: 'Bearer token-2',
+                'x-node-env': 'test',
+              }),
               cache: 'no-store',
             },
           );

--- a/packages/edge-config/src/index.common.test.ts
+++ b/packages/edge-config/src/index.common.test.ts
@@ -4,9 +4,12 @@
 // - @edge-runtime/jest-environment
 // - node
 import fetchMock from 'jest-fetch-mock';
+import { version as pkgVersion } from '../package.json';
 import type { EdgeConfigClient } from './types';
 import { cache } from './utils/fetch-with-cached-response';
 import * as pkg from './index';
+
+const sdkVersion = typeof pkgVersion === 'string' ? pkgVersion : '';
 
 describe('test conditions', () => {
   it('should have an env var called EDGE_CONFIG', () => {
@@ -81,6 +84,7 @@ describe('when running without lambda layer or via edge function', () => {
             headers: new Headers({
               Authorization: 'Bearer token-2',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -104,6 +108,7 @@ describe('when running without lambda layer or via edge function', () => {
             headers: new Headers({
               Authorization: 'Bearer token-2',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -126,6 +131,7 @@ describe('when running without lambda layer or via edge function', () => {
             headers: new Headers({
               Authorization: 'Bearer token-2',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -173,6 +179,7 @@ describe('etags and if-none-match', () => {
           headers: new Headers({
             Authorization: 'Bearer token-2',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         },
@@ -183,6 +190,7 @@ describe('etags and if-none-match', () => {
           headers: new Headers({
             Authorization: 'Bearer token-2',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             'if-none-match': 'a',
           }),
           cache: 'no-store',
@@ -222,6 +230,7 @@ describe('connectionStrings', () => {
               headers: new Headers({
                 Authorization: 'Bearer token-2',
                 'x-edge-config-vercel-env': 'test',
+                'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
               }),
               cache: 'no-store',
             },

--- a/packages/edge-config/src/index.edge.test.ts
+++ b/packages/edge-config/src/index.edge.test.ts
@@ -25,7 +25,10 @@ describe('default Edge Config', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/item/foo?version=1`, {
-      headers: new Headers({ Authorization: 'Bearer token-1' }),
+      headers: new Headers({
+        Authorization: 'Bearer token-1',
+        'x-node-env': 'test',
+      }),
       cache: 'no-store',
     });
   });
@@ -41,7 +44,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/item/foo?version=1`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -72,7 +78,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/item/foo?version=1`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -99,7 +108,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/item/foo?version=1`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -118,7 +130,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/item/foo?version=1`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -137,7 +152,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/item/foo?version=1`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -154,7 +172,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });
@@ -173,7 +194,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/items?version=1&key=foo&key=bar`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -200,7 +224,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/items?version=1&key=foo&key=bar`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -217,7 +244,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });
@@ -233,7 +263,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });
@@ -252,7 +285,10 @@ describe('default Edge Config', () => {
           `${baseUrl}/item/foo?version=1`,
           {
             method: 'HEAD',
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -284,7 +320,10 @@ describe('default Edge Config', () => {
           `${baseUrl}/item/foo?version=1`,
           {
             method: 'HEAD',
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -312,7 +351,10 @@ describe('default Edge Config', () => {
           `${baseUrl}/item/foo?version=1`,
           {
             method: 'HEAD',
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -329,7 +371,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });
@@ -345,7 +390,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });
@@ -359,7 +407,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });
@@ -375,7 +426,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });

--- a/packages/edge-config/src/index.edge.test.ts
+++ b/packages/edge-config/src/index.edge.test.ts
@@ -1,7 +1,9 @@
 import fetchMock from 'jest-fetch-mock';
+import { version as pkgVersion } from '../package.json';
 import { cache } from './utils/fetch-with-cached-response';
 import { get, has, digest, getAll } from './index';
 
+const sdkVersion = typeof pkgVersion === 'string' ? pkgVersion : '';
 const baseUrl = 'https://edge-config.vercel.com/ecfg-1';
 
 describe('default Edge Config', () => {
@@ -28,6 +30,7 @@ describe('default Edge Config', () => {
       headers: new Headers({
         Authorization: 'Bearer token-1',
         'x-edge-config-vercel-env': 'test',
+        'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
       }),
       cache: 'no-store',
     });
@@ -47,6 +50,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -81,6 +85,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -111,6 +116,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -133,6 +139,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -155,6 +162,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -175,6 +183,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });
@@ -197,6 +206,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -227,6 +237,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -247,6 +258,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });
@@ -266,6 +278,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });
@@ -288,6 +301,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -323,6 +337,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -354,6 +369,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -374,6 +390,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });
@@ -393,6 +410,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });
@@ -410,6 +428,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });
@@ -429,6 +448,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });

--- a/packages/edge-config/src/index.edge.test.ts
+++ b/packages/edge-config/src/index.edge.test.ts
@@ -27,7 +27,7 @@ describe('default Edge Config', () => {
     expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/item/foo?version=1`, {
       headers: new Headers({
         Authorization: 'Bearer token-1',
-        'x-node-env': 'test',
+        'x-edge-config-vercel-env': 'test',
       }),
       cache: 'no-store',
     });
@@ -46,7 +46,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -80,7 +80,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -110,7 +110,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -132,7 +132,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -154,7 +154,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -174,7 +174,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });
@@ -196,7 +196,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -226,7 +226,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -246,7 +246,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });
@@ -265,7 +265,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });
@@ -287,7 +287,7 @@ describe('default Edge Config', () => {
             method: 'HEAD',
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -322,7 +322,7 @@ describe('default Edge Config', () => {
             method: 'HEAD',
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -353,7 +353,7 @@ describe('default Edge Config', () => {
             method: 'HEAD',
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -373,7 +373,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });
@@ -392,7 +392,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });
@@ -409,7 +409,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });
@@ -428,7 +428,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });

--- a/packages/edge-config/src/index.node.test.ts
+++ b/packages/edge-config/src/index.node.test.ts
@@ -44,7 +44,7 @@ describe('default Edge Config', () => {
     expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/item/foo?version=1`, {
       headers: new Headers({
         Authorization: 'Bearer token-1',
-        'x-node-env': 'test',
+        'x-edge-config-vercel-env': 'test',
       }),
       cache: 'no-store',
     });
@@ -63,7 +63,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -97,7 +97,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -127,7 +127,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -149,7 +149,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -171,7 +171,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -191,7 +191,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });
@@ -213,7 +213,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -243,7 +243,7 @@ describe('default Edge Config', () => {
           {
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -263,7 +263,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });
@@ -282,7 +282,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });
@@ -304,7 +304,7 @@ describe('default Edge Config', () => {
             method: 'HEAD',
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -339,7 +339,7 @@ describe('default Edge Config', () => {
             method: 'HEAD',
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -370,7 +370,7 @@ describe('default Edge Config', () => {
             method: 'HEAD',
             headers: new Headers({
               Authorization: 'Bearer token-1',
-              'x-node-env': 'test',
+              'x-edge-config-vercel-env': 'test',
             }),
             cache: 'no-store',
           },
@@ -390,7 +390,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });
@@ -409,7 +409,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });
@@ -426,7 +426,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });
@@ -445,7 +445,7 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
           headers: new Headers({
             Authorization: 'Bearer token-1',
-            'x-node-env': 'test',
+            'x-edge-config-vercel-env': 'test',
           }),
           cache: 'no-store',
         });

--- a/packages/edge-config/src/index.node.test.ts
+++ b/packages/edge-config/src/index.node.test.ts
@@ -1,9 +1,11 @@
 import { readFile } from '@vercel/edge-config-fs';
 import fetchMock from 'jest-fetch-mock';
+import { version as pkgVersion } from '../package.json';
 import type { EmbeddedEdgeConfig } from './types';
 import { cache } from './utils/fetch-with-cached-response';
 import { get, has, digest, createClient, getAll } from './index';
 
+const sdkVersion = typeof pkgVersion === 'string' ? pkgVersion : '';
 const baseUrl = 'https://edge-config.vercel.com/ecfg-1';
 
 // eslint-disable-next-line jest/require-top-level-describe
@@ -45,6 +47,7 @@ describe('default Edge Config', () => {
       headers: new Headers({
         Authorization: 'Bearer token-1',
         'x-edge-config-vercel-env': 'test',
+        'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
       }),
       cache: 'no-store',
     });
@@ -64,6 +67,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -98,6 +102,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -128,6 +133,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -150,6 +156,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -172,6 +179,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -192,6 +200,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });
@@ -214,6 +223,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -244,6 +254,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -264,6 +275,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });
@@ -283,6 +295,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });
@@ -305,6 +318,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -340,6 +354,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -371,6 +386,7 @@ describe('default Edge Config', () => {
             headers: new Headers({
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
+              'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
             }),
             cache: 'no-store',
           },
@@ -391,6 +407,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });
@@ -410,6 +427,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });
@@ -427,6 +445,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });
@@ -446,6 +465,7 @@ describe('default Edge Config', () => {
           headers: new Headers({
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
+            'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
           }),
           cache: 'no-store',
         });

--- a/packages/edge-config/src/index.node.test.ts
+++ b/packages/edge-config/src/index.node.test.ts
@@ -42,7 +42,10 @@ describe('default Edge Config', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/item/foo?version=1`, {
-      headers: new Headers({ Authorization: 'Bearer token-1' }),
+      headers: new Headers({
+        Authorization: 'Bearer token-1',
+        'x-node-env': 'test',
+      }),
       cache: 'no-store',
     });
   });
@@ -58,7 +61,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/item/foo?version=1`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -89,7 +95,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/item/foo?version=1`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -116,7 +125,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/item/foo?version=1`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -135,7 +147,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/item/foo?version=1`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -154,7 +169,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/item/foo?version=1`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -171,7 +189,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });
@@ -190,7 +211,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/items?version=1&key=foo&key=bar`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -217,7 +241,10 @@ describe('default Edge Config', () => {
         expect(fetchMock).toHaveBeenCalledWith(
           `${baseUrl}/items?version=1&key=foo&key=bar`,
           {
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -234,7 +261,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });
@@ -250,7 +280,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });
@@ -269,7 +302,10 @@ describe('default Edge Config', () => {
           `${baseUrl}/item/foo?version=1`,
           {
             method: 'HEAD',
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -301,7 +337,10 @@ describe('default Edge Config', () => {
           `${baseUrl}/item/foo?version=1`,
           {
             method: 'HEAD',
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -329,7 +368,10 @@ describe('default Edge Config', () => {
           `${baseUrl}/item/foo?version=1`,
           {
             method: 'HEAD',
-            headers: new Headers({ Authorization: 'Bearer token-1' }),
+            headers: new Headers({
+              Authorization: 'Bearer token-1',
+              'x-node-env': 'test',
+            }),
             cache: 'no-store',
           },
         );
@@ -346,7 +388,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });
@@ -362,7 +407,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });
@@ -376,7 +424,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });
@@ -392,7 +443,10 @@ describe('default Edge Config', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {
-          headers: new Headers({ Authorization: 'Bearer token-1' }),
+          headers: new Headers({
+            Authorization: 'Bearer token-1',
+            'x-node-env': 'test',
+          }),
           cache: 'no-store',
         });
       });

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -1,4 +1,5 @@
 import { readFile } from '@vercel/edge-config-fs';
+import { name as sdkName, version as sdkVersion } from '../package.json';
 import {
   assertIsKey,
   assertIsKeys,
@@ -170,6 +171,9 @@ export function createClient(
 
   if (typeof process !== 'undefined' && process.env.VERCEL_ENV)
     headers['x-edge-config-vercel-env'] = process.env.VERCEL_ENV;
+
+  if (typeof sdkName === 'string' && typeof sdkVersion === 'string')
+    headers['x-edge-config-sdk'] = `${sdkName}@${sdkVersion}`;
 
   return {
     async get<T = EdgeConfigValue>(key: string): Promise<T | undefined> {

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -164,7 +164,12 @@ export function createClient(
 
   const baseUrl = connection.baseUrl;
   const version = connection.version; // version of the edge config read access api we talk to
-  const headers = { Authorization: `Bearer ${connection.token}` };
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${connection.token}`,
+  };
+
+  if (typeof process !== 'undefined' && process.env.NODE_ENV)
+    headers['x-node-env'] = process.env.NODE_ENV;
 
   return {
     async get<T = EdgeConfigValue>(key: string): Promise<T | undefined> {

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -168,8 +168,8 @@ export function createClient(
     Authorization: `Bearer ${connection.token}`,
   };
 
-  if (typeof process !== 'undefined' && process.env.NODE_ENV)
-    headers['x-node-env'] = process.env.NODE_ENV;
+  if (typeof process !== 'undefined' && process.env.VERCEL_ENV)
+    headers['x-edge-config-vercel-env'] = process.env.VERCEL_ENV;
 
   return {
     async get<T = EdgeConfigValue>(key: string): Promise<T | undefined> {

--- a/packages/edge-config/tsconfig.json
+++ b/packages/edge-config/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "tsconfig/base.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  },
   "include": ["src"]
 }


### PR DESCRIPTION
 - Adds `x-edge-config-vercel-env` as a header to requests to provide a way to differentiate between development and other origins
 - Adds `x-edge-config-sdk` as a header to requests to see the version of the SDK that was used