### PR TITLE
docs(contributing): add instructions on how to develop modules

### DIFF
--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -22,8 +22,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup && cp src/undici-browser.js dist/undici-browser.js && cp src/crypto-browser.js dist/crypto-browser.js",
-    "dev": "cp src/undici-browser.js dist/undici-browser.js && tsup --watch --clean=false",
+    "build": "tsup && pnpm run copy-shims",
+    "copy-shims": "cp src/undici-browser.js dist/undici-browser.js && cp src/crypto-browser.js dist/crypto-browser.js",
+    "dev": "pnpm run copy-shims && tsup --watch --clean=false",
     "lint": "eslint --max-warnings=0 .",
     "prepublishOnly": "pnpm run build",
     "prettier-check": "prettier --check .",

--- a/packages/edge-config/package.json
+++ b/packages/edge-config/package.json
@@ -22,6 +22,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "dev": "tsup --watch --clean=false",
     "lint": "eslint --max-warnings=0 .",
     "prepublishOnly": "pnpm run build",
     "prettier-check": "prettier --check .",

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -32,6 +32,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "dev": "tsup --watch --clean=false",
     "lint": "eslint --max-warnings=0 .",
     "prepublishOnly": "pnpm run build",
     "prettier-check": "prettier --check .",

--- a/packages/postgres-kysely/package.json
+++ b/packages/postgres-kysely/package.json
@@ -35,6 +35,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "dev": "tsup --watch --clean=false",
     "lint": "eslint \"**/*.ts\"",
     "prepublishOnly": "pnpm run build",
     "prettier-check": "prettier --check .",

--- a/test/next/README.md
+++ b/test/next/README.md
@@ -6,6 +6,12 @@ Instructions:
 - `pnpm i`
 - `pnpm dev`
 
+To develop one specific module and have it rebuild on change:
+
+```sh
+pnpm --filter @vercel/blob dev
+```
+
 The root page provides links to test suites. You can visit these test suites to quickly debug packages as you're developing them -- refreshing the page will fire off requests in every environment we test for and make sure they come back successfully.
 
 This also deploys to a preview branch for every PR, so you can test your code in production!


### PR DESCRIPTION
Running `pnpm dev` in the `test/next` folder is not sufficient, as packages/ are not rebuilt so you can't make changes and see them working easily.

With this change, you can now run a dev script in most packages so you can load urls from the test/next folder and have them use new code immediately. Without rebuilding.