### PR TITLE
fix(postgres/proxy): correctly bind Pool methods to their corresponding context

### DIFF
--- a/.changeset/metal-eels-invite.md
+++ b/.changeset/metal-eels-invite.md
@@ -1,0 +1,13 @@
+---
+"@vercel/postgres": patch
+---
+
+Before this release, when using our default pooling client (`import { sql } from '@vercel/storage'`), and deploying on Vercel Edge Functions,
+then your Edge Functions would timeout after 11 requests.
+
+Full explanation: we set node-postgres Pool `maxUses` parameter to `1` in Edge Function, because clients can't be reused between requests in this serverless context.
+This combined with how our module is made (a JavaScript proxy) triggered a specific condition where clients would never be released to the Pool.
+
+The exact line that failed under these circumstances was: https://github.com/brianc/node-postgres/blob/735683c5cb41bcbf043c6490be4b7f38cfe3ac48/packages/pg-pool/index.js#L166
+
+This is now fixed, thanks @cramforce.

--- a/.changeset/metal-eels-invite.md
+++ b/.changeset/metal-eels-invite.md
@@ -1,5 +1,5 @@
 ---
-"@vercel/postgres": patch
+'@vercel/postgres': patch
 ---
 
 Before this release, when using our default pooling client (`import { sql } from '@vercel/storage'`), and deploying on Vercel Edge Functions,

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -25,8 +25,14 @@ export const sql = new Proxy(
 
       // keep an eye on this -- it'll fail on certain cases, like private property access, which can
       // require weird things like binding or calling with an explicit `this` arg.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const val = Reflect.get(pool, prop);
+      if (typeof val === 'function') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        return val.bind(pool);
+      }
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return Reflect.get(pool, prop);
+      return val;
     },
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     apply(_, __, argumentsList) {


### PR DESCRIPTION
Before this commit, this pattern would fail to behave properly:

```ts
import { sql } from '@vercel/storage';
const client = await sql.connect();
client.query('...');
client.release(); // this failed before this commit
```

The actual failure was here: https://github.com/brianc/node-postgres/blob/735683c5cb41bcbf043c6490be4b7f38cfe3ac48/packages/pg-pool/index.js#L166

This line would fail when relying on our JavaScript proxy. 