### PR TITLE
add connection info to edge config clients

### DIFF
--- a/.changeset/tall-bugs-drive.md
+++ b/.changeset/tall-bugs-drive.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': minor
+---
+
+adds connection info to edge config clients

--- a/packages/edge-config/src/index.common.test.ts
+++ b/packages/edge-config/src/index.common.test.ts
@@ -216,6 +216,18 @@ describe('connectionStrings', () => {
       expect(typeof pkg.createClient).toBe('function');
     });
 
+    describe('connection', () => {
+      it('should contain the info parsed from the connection string', () => {
+        expect(edgeConfig.connection).toEqual({
+          baseUrl: 'https://example.com/ecfg-2',
+          id: 'ecfg-2',
+          token: 'token-2',
+          type: 'external',
+          version: '1',
+        });
+      });
+    });
+
     describe('get', () => {
       describe('when item exists', () => {
         it('should fetch using information from the passed token', async () => {

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -11,6 +11,7 @@ import {
   pick,
 } from './utils';
 import type {
+  Connection,
   EdgeConfigClient,
   EdgeConfigItems,
   EdgeConfigValue,
@@ -59,22 +60,6 @@ async function consumeResponseBodyInNodeJsRuntimeToPreventMemoryLeak(
   // see https://github.com/node-fetch/node-fetch/issues/83
   await res.arrayBuffer();
 }
-
-type Connection =
-  | {
-      baseUrl: string;
-      id: string;
-      token: string;
-      version: string;
-      type: 'vercel';
-    }
-  | {
-      baseUrl: string;
-      id: string;
-      token: string;
-      version: string;
-      type: 'external';
-    };
 
 /**
  * Parses info contained in connection strings.
@@ -176,6 +161,7 @@ export function createClient(
     headers['x-edge-config-sdk'] = `${sdkName}@${sdkVersion}`;
 
   return {
+    connection,
     async get<T = EdgeConfigValue>(key: string): Promise<T | undefined> {
       const localEdgeConfig = await getFileSystemEdgeConfig(connection);
       if (localEdgeConfig) {

--- a/packages/edge-config/src/types.ts
+++ b/packages/edge-config/src/types.ts
@@ -4,11 +4,34 @@ export interface EmbeddedEdgeConfig {
 }
 
 /**
+ * The parsed info contained in a connection string.
+ */
+export type Connection =
+  | {
+      baseUrl: string;
+      id: string;
+      token: string;
+      version: string;
+      type: 'vercel';
+    }
+  | {
+      baseUrl: string;
+      id: string;
+      token: string;
+      version: string;
+      type: 'external';
+    };
+
+/**
  * An Edge Config Client.
  *
  * You can create new Edge Config clients using createClient().
  */
 export interface EdgeConfigClient {
+  /**
+   * The parsed info from the connection string which was used to create this client.
+   */
+  connection: Connection;
   /**
    * Read a single value.
    *


### PR DESCRIPTION
It's currently possible to create an Edge Config client like so

```
const client = createClient(process.env.EDGE_CONFIG)
```

But when any function receives a fully configured client as an argument, it currently has no way of e.g. knowing the id of the edge config this client connects to.

To make this possible, this PR is adding the `connection` info to the client itself.

You can now do `client.connection.id` to read the Edge Config Id.

The full info available on the connection is

```json5
{
  baseUrl: 'https://example.com/ecfg-2', // this is usually https://edge-config.vercel.com/:edgeConfigId
  id: 'ecfg-2', // the edge config id
  token: 'token-2', // the token used to connect
  type: 'external', // whether this edge config is hosted on edge-config.vercel.com or not
  version: '1', // the api version supplied in the connection string, this is always "1" at the moment
}
```