### PR TITLE
[docs] Add docs about support for streams in @vercel/kv package

### DIFF
--- a/packages/kv/README.md
+++ b/packages/kv/README.md
@@ -134,3 +134,20 @@ const kv = createClient({
 
 await kv.set('key', 'value');
 ```
+
+## FAQ
+
+### Does the `@vercel/kv` package support [Redis Streams](https://redis.io/docs/data-types/streams/)?
+
+No, the `@vercel/kv` package does not support Redis Streams. To use Redis Streams with Vercel KV, you must connect directly to the database server via packacges like [`io-redis`](https://github.com/redis/ioredis) or [`node-redis`](https://github.com/redis/node-redis).
+
+```js
+import { createClient } from 'redis';
+
+const client = createClient({
+  url: process.env.KV_URL,
+});
+
+await client.connect();
+await client.xRead({ key: 'mystream', id: '0' }, { COUNT: 2 });
+```


### PR DESCRIPTION
Addresses https://github.com/vercel/storage/issues/278.

This PR adds a note about the support for Redis Streams with the `@vercel/kv` package.