### PR TITLE
docs(blob): Refer to vercel.com documentation, precise 4 MB

### DIFF
--- a/test/next/src/app/vercel/blob/app/body/edge/page.tsx
+++ b/test/next/src/app/vercel/blob/app/body/edge/page.tsx
@@ -23,7 +23,7 @@ export default function AppBodyEdge(): JSX.Element {
         .
       </p>
       <p>
-        Note: When deployed on Vercel, there&apos;s a 4MB file upload limit.
+        Note: When deployed on Vercel, there&apos;s a 4.5 MB file upload limit.
       </p>
       <FormBodyUpload action="/vercel/blob/api/app/body/edge" />
     </>

--- a/test/next/src/app/vercel/blob/app/body/serverless/page.tsx
+++ b/test/next/src/app/vercel/blob/app/body/serverless/page.tsx
@@ -23,7 +23,7 @@ export default function AppFormDataServerless(): JSX.Element {
         .
       </p>
       <p>
-        Note: When deployed on Vercel, there&apos;s a 4MB file upload limit.
+        Note: When deployed on Vercel, there&apos;s a 4.5 MB file upload limit.
       </p>
       <FormBodyUpload action="/vercel/blob/api/app/body/edge" />
     </>

--- a/test/next/src/app/vercel/blob/app/formdata/edge/page.tsx
+++ b/test/next/src/app/vercel/blob/app/formdata/edge/page.tsx
@@ -27,7 +27,7 @@ export default function AppFormDataEdge(): JSX.Element {
         .
       </p>
       <p>
-        Note: When deployed on Vercel, there&apos;s a 4MB file upload limit.
+        Note: When deployed on Vercel, there&apos;s a 4.5 MB file upload limit.
       </p>
       <FormDataUpload action="/vercel/blob/api/app/formdata/edge" />
     </>

--- a/test/next/src/app/vercel/blob/app/formdata/serverless/page.tsx
+++ b/test/next/src/app/vercel/blob/app/formdata/serverless/page.tsx
@@ -27,7 +27,7 @@ export default function AppFormDataServerless(): JSX.Element {
         .
       </p>
       <p>
-        Note: When deployed on Vercel, there&apos;s a 4MB file upload limit.
+        Note: When deployed on Vercel, there&apos;s a 4.5 MB file upload limit.
       </p>
       <FormDataUpload action="/vercel/blob/api/app/formdata/serverless" />
     </>

--- a/test/next/src/app/vercel/blob/handle-body.ts
+++ b/test/next/src/app/vercel/blob/handle-body.ts
@@ -14,6 +14,7 @@ export async function handleBody(request: Request): Promise<NextResponse> {
       },
     );
   }
+
   if (!validateUploadToken(request)) {
     return NextResponse.json(
       { message: 'Not authorized' },

--- a/test/next/src/app/vercel/blob/page.tsx
+++ b/test/next/src/app/vercel/blob/page.tsx
@@ -9,8 +9,8 @@ export default function Home(): JSX.Element {
         )
       </h1>
       <p>
-        Note: When deployed on Vercel, there&apos;s a 4MB file upload limit for
-        browsers.
+        Note: When deployed on Vercel, there&apos;s a 4.5 MB file upload limit
+        for browsers.
       </p>
       <p>
         Node.js https.get, axios, and got examples can be found in the{' '}

--- a/test/next/test/@vercel/blob/index.test.ts
+++ b/test/next/test/@vercel/blob/index.test.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 import { test, expect } from '@playwright/test';
-import { type PutBlobResult } from '@vercel/blob';
+import type { PutBlobResult } from '@vercel/blob';
 
 const prefix = `${
   process.env.GITHUB_PR_NUMBER || crypto.randomBytes(10).toString('hex')


### PR DESCRIPTION
- The limit is actually 4.5 MB
- Let's reference vercel.com examples instead of copy pasting examples everywhere
- Let's still keep this README API documentation as the source of truth