### PR TITLE
Add postgresql adapter for Kysely

### DIFF
--- a/packages/postgres-kysely/src/index.ts
+++ b/packages/postgres-kysely/src/index.ts
@@ -1,17 +1,60 @@
-import type { DatabaseConnection, Dialect, Driver } from 'kysely';
-import { PostgresDialect, PostgresDriver, Kysely } from 'kysely';
+import type {
+  DatabaseConnection,
+  Dialect,
+  DialectAdapter,
+  DialectAdapterBase,
+  Driver,
+  MigrationLockOptions,
+} from 'kysely';
+import {
+  PostgresDialect,
+  PostgresDriver,
+  Kysely,
+  PostgresAdapter,
+  sql,
+} from 'kysely';
 import type { Pool } from '@neondatabase/serverless';
 import { createPool } from '@vercel/postgres';
 import type { VercelPostgresPoolConfig } from '@vercel/postgres';
 import { VercelPostgresKyselyError } from './error';
 
+// Random id for our transaction lock.
+const LOCK_ID = BigInt('3853314791062309107');
+
 type VercelPostgresDialectConfig = VercelPostgresPoolConfig & {
   pool: Pool;
 };
 
+class VercelPostgresAdapter
+  extends PostgresAdapter
+  implements DialectAdapterBase
+{
+  get supportsTransactionalDdl(): boolean {
+    return false;
+  }
+
+  async acquireMigrationLock(
+    db: Kysely<any>,
+    _opt: MigrationLockOptions,
+  ): Promise<void> {
+    await sql`select pg_advisory_lock(${sql.lit(LOCK_ID)})`.execute(db);
+  }
+
+  async releaseMigrationLock(
+    db: Kysely<any>,
+    _opt: MigrationLockOptions,
+  ): Promise<void> {
+    await sql`select pg_advisory_unlock(${sql.lit(LOCK_ID)})`.execute(db);
+  }
+}
+
 class VercelPostgresDialect extends PostgresDialect implements Dialect {
   constructor(private config: VercelPostgresDialectConfig) {
     super(config);
+  }
+
+  createAdapter(): DialectAdapter {
+    return new VercelPostgresAdapter();
   }
 
   createDriver(): Driver {

--- a/packages/postgres-kysely/src/index.ts
+++ b/packages/postgres-kysely/src/index.ts
@@ -25,25 +25,20 @@ type VercelPostgresDialectConfig = VercelPostgresPoolConfig & {
   pool: Pool;
 };
 
-class VercelPostgresAdapter
-  extends PostgresAdapter
-  implements DialectAdapterBase
-{
+class VercelPostgresAdapter implements DialectAdapterBase {
   get supportsTransactionalDdl(): boolean {
     return false;
   }
 
-  async acquireMigrationLock(
-    db: Kysely<any>,
-    _opt: MigrationLockOptions,
-  ): Promise<void> {
+  get supportsReturning(): boolean {
+    return true;
+  }
+
+  async acquireMigrationLock(db: Kysely<any>): Promise<void> {
     await sql`select pg_advisory_lock(${sql.lit(LOCK_ID)})`.execute(db);
   }
 
-  async releaseMigrationLock(
-    db: Kysely<any>,
-    _opt: MigrationLockOptions,
-  ): Promise<void> {
+  async releaseMigrationLock(db: Kysely<any>): Promise<void> {
     await sql`select pg_advisory_unlock(${sql.lit(LOCK_ID)})`.execute(db);
   }
 }


### PR DESCRIPTION
The original problem I had which triggered this change was this error when running migrations as documented in https://kysely.dev/docs/migrations

```
VercelPostgresKyselyError [VercelPostgresError]: VercelPostgresError - 'kysely_transactions_not_supported': Transactions are not supported yet.
```

Which we get because we haven't properly signaled to Kysely that we don't support transactions. The Kysely migrator checks `supportsTransactionalDdl` to decide whether to run migrations in a transaction or not, so this adds that.

It also overrides the default migration lock functions from https://github.com/kysely-org/kysely/blob/master/src/dialect/postgres/postgres-adapter.ts to use `pg_advisory_lock` and then unlock with `pg_advisory_unlock` since we can't rely on transactions auto-dropping now.

Fixes #325