### PR TITLE
feat(blob): add addRandomSuffix option to disable automatic ids on put

### DIFF
--- a/packages/blob/README.md
+++ b/packages/blob/README.md
@@ -109,7 +109,8 @@ async function handleBlobUpload(options?: {
   onBeforeGenerateToken: (pathname: string) => Promise<{
     allowedContentTypes?: string[]; // optional, defaults to no restriction
     maximumSizeInBytes?: number; // optional, defaults and maximum is 500MB (524,288,000 bytes)
-    validUntil?: number; // optional, timestamp in ms, by default now + 30s
+    validUntil?: number; // optional, timestamp in ms, by default now + 30s (30,000)
+    addRandomSuffix?: boolean; // optional, allows to disable or enable random suffixes
     metadata?: string;
   }>;
   onUploadCompleted: (body: {
@@ -155,7 +156,8 @@ async function generateClientTokenFromReadWriteToken(options?: {
   };
   maximumSizeInBytes?: number;
   allowedContentTypes?: string[];
-  validUntil?: number; // timestamp in ms, by default 30s
+  validUntil?: number; // optional, timestamp in ms, by default now + 30s (30,000)
+  addRandomSuffix?: boolean; // optional, allows to disable or enable random suffixes, `true` by default
 }): string {}
 ```
 

--- a/packages/blob/src/client-upload.ts
+++ b/packages/blob/src/client-upload.ts
@@ -13,6 +13,7 @@ export interface GenerateClientTokenOptions extends BlobCommandOptions {
   maximumSizeInBytes?: number;
   allowedContentTypes?: string[];
   validUntil?: number;
+  addRandomSuffix?: boolean;
 }
 
 export async function generateClientTokenFromReadWriteToken({
@@ -172,7 +173,10 @@ export interface HandleBlobUploadOptions {
   ) => Promise<
     Pick<
       GenerateClientTokenOptions,
-      'allowedContentTypes' | 'maximumSizeInBytes' | 'validUntil'
+      | 'allowedContentTypes'
+      | 'maximumSizeInBytes'
+      | 'validUntil'
+      | 'addRandomSuffix'
     > & { metadata?: string }
   >;
   onUploadCompleted: (

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -439,6 +439,26 @@ describe('blob client', () => {
         })
       ).rejects.toThrow(new Error('Vercel Blob: access must be "public"'));
     });
+
+    it('sets the correct header when using the addRandomSuffix option', async () => {
+      let headers: Record<string, string> = {};
+
+      mockClient
+        .intercept({
+          path: () => true,
+          method: 'PUT',
+        })
+        .reply(200, (req) => {
+          headers = req.headers as Record<string, string>;
+          return mockedFileMetaPut;
+        });
+
+      await put('foo.txt', 'Test Body', {
+        access: 'public',
+        addRandomSuffix: false,
+      });
+      expect(headers['x-add-random-suffix']).toEqual('0');
+    });
   });
 
   describe('generateClientTokenFromReadWriteToken', () => {

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -14,10 +14,6 @@ import {
 
 const BLOB_API_URL = 'https://blob.vercel-storage.com';
 const BLOB_STORE_BASE_URL = 'https://storeId.public.blob.vercel-storage.com';
-const mockAgent = new MockAgent();
-mockAgent.disableNetConnect();
-
-setGlobalDispatcher(mockAgent);
 
 const mockedFileMeta = {
   url: `${BLOB_STORE_BASE_URL}/foo-id.txt`,
@@ -33,6 +29,9 @@ describe('blob client', () => {
 
   beforeEach(() => {
     process.env.BLOB_READ_WRITE_TOKEN = 'TEST_TOKEN';
+    const mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+    setGlobalDispatcher(mockAgent);
     mockClient = mockAgent.get(BLOB_API_URL);
     jest.resetAllMocks();
   });

--- a/packages/blob/src/index.ts
+++ b/packages/blob/src/index.ts
@@ -37,7 +37,8 @@ export interface BlobCommandOptions {
 export interface PutCommandOptions extends BlobCommandOptions {
   access: 'public';
   contentType?: string;
-  handleBlobUploadUrl?: string;
+  handleBlobUploadUrl?: string; // only used in the browser
+  addRandomSuffix?: boolean;
 }
 
 export interface PutBlobResult {
@@ -88,6 +89,10 @@ export async function put(
 
   if (options.contentType) {
     headers['x-content-type'] = options.contentType;
+  }
+
+  if (options.addRandomSuffix !== undefined) {
+    headers['x-add-random-suffix'] = options.addRandomSuffix ? '1' : '0';
   }
 
   const blobApiResponse = await fetch(getApiUrl(`/${pathname}`), {

--- a/test/next/src/app/vercel/blob/script.ts
+++ b/test/next/src/app/vercel/blob/script.ts
@@ -19,6 +19,7 @@ console.log();
 async function run(): Promise<void> {
   const urls = await Promise.all([
     textFileExample(),
+    textFileNoRandomSuffixExample(),
     imageExample(),
     videoExample(),
     webpageExample(),
@@ -32,7 +33,7 @@ async function run(): Promise<void> {
 
   await Promise.all(
     urls.map(async (url) => {
-      const blobDetails = await vercelBlob.head(url as string);
+      const blobDetails = await vercelBlob.head(url);
       console.log(blobDetails, url);
     })
   );
@@ -53,14 +54,32 @@ async function run(): Promise<void> {
 
   console.log(count, 'blobs in this store');
 
-  await Promise.all(urls.map((url) => vercelBlob.del(url as string)));
+  await Promise.all(urls.map((url) => vercelBlob.del(url)));
 }
 
 async function textFileExample(): Promise<string> {
   const start = Date.now();
-  const blob = await vercelBlob.put('folder/test.txt', 'Hello, world!', {
-    access: 'public',
-  });
+  const blob = await vercelBlob.put(
+    'folder/test.txt',
+    'Hello, wosdsdsdsa1222rld!',
+    {
+      access: 'public',
+    }
+  );
+  console.log('Text file example:', blob.url, `(${Date.now() - start}ms)`);
+  return blob.url;
+}
+
+async function textFileNoRandomSuffixExample(): Promise<string> {
+  const start = Date.now();
+  const blob = await vercelBlob.put(
+    'folder/test.txt',
+    'Hello, wosdsdsdsa1222rld!',
+    {
+      access: 'public',
+      addRandomSuffix: false,
+    }
+  );
   console.log('Text file example:', blob.url, `(${Date.now() - start}ms)`);
   return blob.url;
 }

--- a/test/next/src/app/vercel/blob/script.ts
+++ b/test/next/src/app/vercel/blob/script.ts
@@ -194,26 +194,23 @@ async function gotExample(): Promise<string> {
   return blob.url;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- [@vercel/style-guide@5 migration]
-async function fetchExample(): Promise<string | void> {
+async function fetchExample(): Promise<string> {
   const start = Date.now();
 
   const response = await fetch(
     'https://example-files.online-convert.com/video/mp4/example_2s.mp4'
   );
 
-  if (response.body) {
-    const blob = await vercelBlob.put(
-      'example_2s.mp4',
-      response.body as ReadableStream,
-      {
-        access: 'public',
-      }
-    );
+  const blob = await vercelBlob.put(
+    'example_2s.mp4',
+    response.body as ReadableStream,
+    {
+      access: 'public',
+    }
+  );
 
-    console.log('fetch example:', blob.url, `(${Date.now() - start}ms)`);
-    return blob.url;
-  }
+  console.log('fetch example:', blob.url, `(${Date.now() - start}ms)`);
+  return blob.url;
 }
 
 run().catch((err) => {

--- a/test/next/src/app/vercel/blob/script.ts
+++ b/test/next/src/app/vercel/blob/script.ts
@@ -59,27 +59,19 @@ async function run(): Promise<void> {
 
 async function textFileExample(): Promise<string> {
   const start = Date.now();
-  const blob = await vercelBlob.put(
-    'folder/test.txt',
-    'Hello, wosdsdsdsa1222rld!',
-    {
-      access: 'public',
-    }
-  );
+  const blob = await vercelBlob.put('folder/test.txt', 'Hello, world!', {
+    access: 'public',
+  });
   console.log('Text file example:', blob.url, `(${Date.now() - start}ms)`);
   return blob.url;
 }
 
 async function textFileNoRandomSuffixExample(): Promise<string> {
   const start = Date.now();
-  const blob = await vercelBlob.put(
-    'folder/test.txt',
-    'Hello, wosdsdsdsa1222rld!',
-    {
-      access: 'public',
-      addRandomSuffix: false,
-    }
-  );
+  const blob = await vercelBlob.put('folder/test.txt', 'Hello, world!', {
+    access: 'public',
+    addRandomSuffix: false,
+  });
   console.log('Text file example:', blob.url, `(${Date.now() - start}ms)`);
   return blob.url;
 }


### PR DESCRIPTION
This new options allows you to disable the addition of automatic id suffixes to
pathnames.

example:

```ts
const blobWithoutAutomaticSuffix = await put('welcome.txt', 'Hello world!', {
  access: 'public',
  addRandomSuffix: false
});

// 'https://$storeId.public.blob.vercel-storage.com/welcome.txt'
console.log(blobWithoutAutomaticSuffix.url);

const blobWithAutomaticSuffix = await put('bye.txt', 'Hello world!', {
  access: 'public'
});

// 'https://$storeId.public.blob.vercel-storage.com/bye-$someRandomId.txt'
console.log(blobWithAutomaticSuffix.url);
```

fixes STO-780

This also means you can now override blobs. We're planning to allow you to
configure the cache also, stay tuned.