### PR TITLE
feat(blob): add `clientPayload` and `tokenPayload`

### DIFF
--- a/packages/blob/src/client.edge.test.ts
+++ b/packages/blob/src/client.edge.test.ts
@@ -5,7 +5,6 @@ import {
 
 describe('blob client', () => {
   beforeEach(() => {
-    process.env.BLOB_READ_WRITE_TOKEN = 'TEST_TOKEN';
     jest.resetAllMocks();
   });
 
@@ -23,22 +22,24 @@ describe('blob client', () => {
         pathname: 'foo.txt',
         onUploadCompleted: {
           callbackUrl: 'https://example.com',
-          metadata: JSON.stringify({ foo: 'bar' }),
+          tokenPayload: JSON.stringify({ foo: 'bar' }),
         },
-        token: 'vercel_blob_client_123456789_TEST_TOKEN',
+        token: 'vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678',
       });
-      expect(uploadToken).toEqual(
-        'vercel_blob_client_123456789_YWVlNmY1ZjVkZGU5YWZiYjczOGE1YmM0ZTNiOGFjNTI3MGNlMTJhOTNiNDc1YTlmZjBmYjkyZTFlZWVhNGE2OS5leUp3WVhSb2JtRnRaU0k2SW1admJ5NTBlSFFpTENKdmJsVndiRzloWkVOdmJYQnNaWFJsWkNJNmV5SmpZV3hzWW1GamExVnliQ0k2SW1oMGRIQnpPaTh2WlhoaGJYQnNaUzVqYjIwaUxDSnRaWFJoWkdGMFlTSTZJbnRjSW1admIxd2lPbHdpWW1GeVhDSjlJbjBzSW5aaGJHbGtWVzUwYVd3aU9qRTJOekkxTXpFeU16QXdNREI5'
+      expect(uploadToken).toMatchInlineSnapshot(
+        `"vercel_blob_client_12345fakeStoreId_N2I2NTAxOGI1Y2IwZDhlY2VlZGUyYTQ2YjE1ZmJhODRlYjU3M2Q5MjBlNjNiYmI4NmQ0ZTRhOTJhZmM1NTVjMi5leUp3WVhSb2JtRnRaU0k2SW1admJ5NTBlSFFpTENKdmJsVndiRzloWkVOdmJYQnNaWFJsWkNJNmV5SmpZV3hzWW1GamExVnliQ0k2SW1oMGRIQnpPaTh2WlhoaGJYQnNaUzVqYjIwaUxDSjBiMnRsYmxCaGVXeHZZV1FpT2lKN1hDSm1iMjljSWpwY0ltSmhjbHdpZlNKOUxDSjJZV3hwWkZWdWRHbHNJam94TmpjeU5UTXhNak13TURBd2ZRPT0="`
       );
 
-      expect(getPayloadFromClientToken(uploadToken)).toEqual({
-        pathname: 'foo.txt',
-        onUploadCompleted: {
-          callbackUrl: 'https://example.com',
-          metadata: '{"foo":"bar"}',
-        },
-        validUntil: 1672531230000,
-      });
+      expect(getPayloadFromClientToken(uploadToken)).toMatchInlineSnapshot(`
+        {
+          "onUploadCompleted": {
+            "callbackUrl": "https://example.com",
+            "tokenPayload": "{"foo":"bar"}",
+          },
+          "pathname": "foo.txt",
+          "validUntil": 1672531230000,
+        }
+      `);
     });
   });
 });

--- a/packages/blob/src/client.node.test.ts
+++ b/packages/blob/src/client.node.test.ts
@@ -7,10 +7,6 @@ import {
 import type { PutBlobResult } from '.';
 
 describe('client uploads', () => {
-  beforeEach(() => {
-    process.env.BLOB_READ_WRITE_TOKEN = 'TEST_TOKEN';
-  });
-
   describe('generateClientTokenFromReadWriteToken', () => {
     afterEach(() => {
       jest.runOnlyPendingTimers();
@@ -21,25 +17,25 @@ describe('client uploads', () => {
       jest.useFakeTimers().setSystemTime(new Date('2023-01-01'));
     });
 
-    test('should generate a client token with the correct payload', async () => {
+    it('should generate a client token with the correct payload', async () => {
       const uploadToken = await generateClientTokenFromReadWriteToken({
         pathname: 'foo.txt',
         onUploadCompleted: {
           callbackUrl: 'https://example.com',
-          metadata: JSON.stringify({ foo: 'bar' }),
+          tokenPayload: JSON.stringify({ foo: 'bar' }),
         },
-        token: 'vercel_blob_client_123456789_TEST_TOKEN',
+        token: 'vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678',
       });
 
-      expect(uploadToken).toEqual(
-        'vercel_blob_client_123456789_YWVlNmY1ZjVkZGU5YWZiYjczOGE1YmM0ZTNiOGFjNTI3MGNlMTJhOTNiNDc1YTlmZjBmYjkyZTFlZWVhNGE2OS5leUp3WVhSb2JtRnRaU0k2SW1admJ5NTBlSFFpTENKdmJsVndiRzloWkVOdmJYQnNaWFJsWkNJNmV5SmpZV3hzWW1GamExVnliQ0k2SW1oMGRIQnpPaTh2WlhoaGJYQnNaUzVqYjIwaUxDSnRaWFJoWkdGMFlTSTZJbnRjSW1admIxd2lPbHdpWW1GeVhDSjlJbjBzSW5aaGJHbGtWVzUwYVd3aU9qRTJOekkxTXpFeU16QXdNREI5'
+      expect(uploadToken).toMatchInlineSnapshot(
+        `"vercel_blob_client_12345fakeStoreId_N2I2NTAxOGI1Y2IwZDhlY2VlZGUyYTQ2YjE1ZmJhODRlYjU3M2Q5MjBlNjNiYmI4NmQ0ZTRhOTJhZmM1NTVjMi5leUp3WVhSb2JtRnRaU0k2SW1admJ5NTBlSFFpTENKdmJsVndiRzloWkVOdmJYQnNaWFJsWkNJNmV5SmpZV3hzWW1GamExVnliQ0k2SW1oMGRIQnpPaTh2WlhoaGJYQnNaUzVqYjIwaUxDSjBiMnRsYmxCaGVXeHZZV1FpT2lKN1hDSm1iMjljSWpwY0ltSmhjbHdpZlNKOUxDSjJZV3hwWkZWdWRHbHNJam94TmpjeU5UTXhNak13TURBd2ZRPT0="`
       );
 
       expect(getPayloadFromClientToken(uploadToken)).toEqual({
         pathname: 'foo.txt',
         onUploadCompleted: {
           callbackUrl: 'https://example.com',
-          metadata: '{"foo":"bar"}',
+          tokenPayload: '{"foo":"bar"}',
         },
         validUntil: 1672531230000,
       });
@@ -55,8 +51,9 @@ describe('client uploads', () => {
     beforeEach(() => {
       jest.useFakeTimers().setSystemTime(new Date('2023-01-01'));
     });
-    test('should return client token when called with blob.generate-client-token', async () => {
-      const token = 'vercel_blob_client_123456789_TEST_TOKEN';
+    it('should return client token when called with blob.generate-client-token', async () => {
+      const token =
+        'vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678';
       const spy = jest.fn();
       const jsonResponse = await handleUpload({
         token,
@@ -73,7 +70,7 @@ describe('client uploads', () => {
         onBeforeGenerateToken: async (pathname) => {
           await Promise.resolve();
           return Promise.resolve({
-            metadata: pathname,
+            tokenPayload: pathname,
           });
         },
         onUploadCompleted: async (body) => {
@@ -81,27 +78,28 @@ describe('client uploads', () => {
           spy.call(body);
         },
       });
-      expect(jsonResponse).toEqual({
-        clientToken:
-          'vercel_blob_client_123456789_MThhNDRkM2VjZDliYmY3YWE3YmRlNTRiNGMwOTdjNDhiOGQ0NzI3M2NhMmIxOGY2OTEyNTZmOTVkZGJlZjMwNC5leUp0WlhSaFpHRjBZU0k2SW01bGQyWnBiR1V1ZEhoMElpd2ljR0YwYUc1aGJXVWlPaUp1WlhkbWFXeGxMblI0ZENJc0ltOXVWWEJzYjJGa1EyOXRjR3hsZEdWa0lqcDdJbU5oYkd4aVlXTnJWWEpzSWpvaWFIUjBjSE02THk5bGVHRnRjR3hsTG1OdmJTSXNJbTFsZEdGa1lYUmhJam9pYm1WM1ptbHNaUzUwZUhRaWZTd2lkbUZzYVdSVmJuUnBiQ0k2TVRZM01qVXpNVEl6TURBd01IMD0=',
-        type: 'blob.generate-client-token',
-      });
+      expect(jsonResponse).toMatchInlineSnapshot(`
+        {
+          "clientToken": "vercel_blob_client_12345fakeStoreId_ODBiNjcyZDgyZTNkOTYyNTcwMTQ4NTFhNzJlOTEzZmI0MzQ4NWEzNzE0NzhjNGE0ZGRlN2IxMzRmYjI0NTkxOS5leUowYjJ0bGJsQmhlV3h2WVdRaU9pSnVaWGRtYVd4bExuUjRkQ0lzSW5CaGRHaHVZVzFsSWpvaWJtVjNabWxzWlM1MGVIUWlMQ0p2YmxWd2JHOWhaRU52YlhCc1pYUmxaQ0k2ZXlKallXeHNZbUZqYTFWeWJDSTZJbWgwZEhCek9pOHZaWGhoYlhCc1pTNWpiMjBpTENKMGIydGxibEJoZVd4dllXUWlPaUp1WlhkbWFXeGxMblI0ZENKOUxDSjJZV3hwWkZWdWRHbHNJam94TmpjeU5UTXhNak13TURBd2ZRPT0=",
+          "type": "blob.generate-client-token",
+        }
+      `);
       expect(spy).not.toHaveBeenCalled();
       expect(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any -- Either the test is incomplete, or we're messing up with TS
         getPayloadFromClientToken((jsonResponse as any).clientToken)
       ).toEqual({
-        metadata: 'newfile.txt',
+        tokenPayload: 'newfile.txt',
         onUploadCompleted: {
           callbackUrl: 'https://example.com',
-          metadata: 'newfile.txt',
+          tokenPayload: 'newfile.txt',
         },
         pathname: 'newfile.txt',
         validUntil: 1672531230000,
       });
     });
 
-    test('should run onCompleted when called with blob.upload-completed', async () => {
+    it('should run onCompleted when called with blob.upload-completed', async () => {
       const token = 'vercel_blob_client_123456789_TEST_TOKEN';
       const spy = jest.fn();
 
@@ -110,21 +108,23 @@ describe('client uploads', () => {
           token,
           request: {
             headers: {
+              // The next signature was generated via signPayload, export it when necessary
               'x-vercel-signature':
-                '973bfbb82f375e9360675b8271b16e1f44e3dd8c3996560b65c0f0fb3316def2',
+                'a4eac582498d4548d701eb8ff3e754f33f078e75298b9a1a0cdbac128981b28d',
             },
           } as unknown as IncomingMessage,
           body: {
             type: 'blob.upload-completed',
             payload: {
               blob: { pathname: 'newfile.txt' } as PutBlobResult,
-              metadata: 'custom-metadata',
+              tokenPayload: 'custom-metadata',
             },
           },
+          // Next option is only here for type completeness, not used in the test itself
           onBeforeGenerateToken: async (pathname) => {
             await Promise.resolve();
             return {
-              metadata: pathname,
+              tokenPayload: pathname,
             };
           },
           onUploadCompleted: spy,
@@ -135,7 +135,91 @@ describe('client uploads', () => {
       });
       expect(spy).toHaveBeenCalledWith({
         blob: { pathname: 'newfile.txt' } as PutBlobResult,
-        metadata: 'custom-metadata',
+        tokenPayload: 'custom-metadata',
+      });
+    });
+
+    it('uses clientPayload for tokenPayload by default', async () => {
+      const token =
+        'vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678';
+      const spy = jest.fn();
+      const jsonResponse = await handleUpload({
+        token,
+        request: {
+          headers: { 'x-vercel-signature': '123' },
+        } as unknown as IncomingMessage,
+        body: {
+          type: 'blob.generate-client-token',
+          payload: {
+            pathname: 'newfile.txt',
+            callbackUrl: 'https://example.com',
+            clientPayload: 'custom-metadata-from-client',
+          },
+        },
+        onBeforeGenerateToken: async () => {
+          await Promise.resolve();
+          return Promise.resolve({
+            addRandomSuffix: false,
+          });
+        },
+        onUploadCompleted: async (body) => {
+          await Promise.resolve();
+          spy.call(body);
+        },
+      });
+      expect(jsonResponse).toMatchInlineSnapshot(`
+        {
+          "clientToken": "vercel_blob_client_12345fakeStoreId_YjgzZDU4YzFkZjM3MmNlN2JhMTk1MmVlYjE4YWMwOTczNGI3NjhlOTljMmE0ZTdiM2M0MTliOGJlNDg5YTFiZS5leUpoWkdSU1lXNWtiMjFUZFdabWFYZ2lPbVpoYkhObExDSndZWFJvYm1GdFpTSTZJbTVsZDJacGJHVXVkSGgwSWl3aWIyNVZjR3h2WVdSRGIyMXdiR1YwWldRaU9uc2lZMkZzYkdKaFkydFZjbXdpT2lKb2RIUndjem92TDJWNFlXMXdiR1V1WTI5dElpd2lkRzlyWlc1UVlYbHNiMkZrSWpvaVkzVnpkRzl0TFcxbGRHRmtZWFJoTFdaeWIyMHRZMnhwWlc1MEluMHNJblpoYkdsa1ZXNTBhV3dpT2pFMk56STFNekV5TXpBd01EQjk=",
+          "type": "blob.generate-client-token",
+        }
+      `);
+      expect(spy).not.toHaveBeenCalled();
+      expect(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any -- Either the test is incomplete, or we're messing up with TS
+        getPayloadFromClientToken((jsonResponse as any).clientToken)
+      ).toMatchInlineSnapshot(`
+        {
+          "addRandomSuffix": false,
+          "onUploadCompleted": {
+            "callbackUrl": "https://example.com",
+            "tokenPayload": "custom-metadata-from-client",
+          },
+          "pathname": "newfile.txt",
+          "validUntil": 1672531230000,
+        }
+      `);
+    });
+
+    it('provides `clientPayload` in onBeforeGenerateToken', async () => {
+      expect.assertions(1);
+
+      const token =
+        'vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678';
+      await handleUpload({
+        token,
+        request: {
+          headers: { 'x-vercel-signature': '123' },
+        } as unknown as IncomingMessage,
+        body: {
+          type: 'blob.generate-client-token',
+          payload: {
+            pathname: 'newfile.txt',
+            callbackUrl: 'https://example.com',
+            clientPayload: 'custom-metadata-from-client-we-expect',
+          },
+        },
+        onBeforeGenerateToken: async (pathname, clientPayload) => {
+          expect(clientPayload).toEqual(
+            'custom-metadata-from-client-we-expect'
+          );
+          await Promise.resolve();
+          return Promise.resolve({
+            addRandomSuffix: false,
+          });
+        },
+        onUploadCompleted: async () => {
+          await Promise.resolve();
+        },
       });
     });
   });

--- a/packages/blob/src/client.node.test.ts
+++ b/packages/blob/src/client.node.test.ts
@@ -17,7 +17,29 @@ describe('client uploads', () => {
       jest.useFakeTimers().setSystemTime(new Date('2023-01-01'));
     });
 
-    it('should generate a client token with the correct payload', async () => {
+    it('generates a client token', async () => {
+      const uploadToken = await generateClientTokenFromReadWriteToken({
+        pathname: 'foo.txt',
+        onUploadCompleted: {
+          callbackUrl: 'https://example.com',
+        },
+        token: 'vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678',
+      });
+
+      expect(uploadToken).toMatchInlineSnapshot(
+        `"vercel_blob_client_12345fakeStoreId_ZTVmZTJmYWZkOWJhMGNiNTVjOGExOWJkM2VhY2M5NzRhNzM4MmQ2NmEyN2EyMmYwMzFkMjQ0ZDIyMjMzN2Y0Yy5leUp3WVhSb2JtRnRaU0k2SW1admJ5NTBlSFFpTENKdmJsVndiRzloWkVOdmJYQnNaWFJsWkNJNmV5SmpZV3hzWW1GamExVnliQ0k2SW1oMGRIQnpPaTh2WlhoaGJYQnNaUzVqYjIwaWZTd2lkbUZzYVdSVmJuUnBiQ0k2TVRZM01qVXpNVEl6TURBd01IMD0="`
+      );
+
+      expect(getPayloadFromClientToken(uploadToken)).toEqual({
+        pathname: 'foo.txt',
+        onUploadCompleted: {
+          callbackUrl: 'https://example.com',
+        },
+        validUntil: 1672531230000,
+      });
+    });
+
+    it('accepts a tokenPayload property', async () => {
       const uploadToken = await generateClientTokenFromReadWriteToken({
         pathname: 'foo.txt',
         onUploadCompleted: {

--- a/packages/blob/src/client.ts
+++ b/packages/blob/src/client.ts
@@ -369,7 +369,7 @@ export interface GenerateClientTokenOptions extends BlobCommandOptions {
   pathname: string;
   onUploadCompleted?: {
     callbackUrl: string;
-    tokenPayload?: string | null;
+    tokenPayload?: string;
   };
   maximumSizeInBytes?: number;
   allowedContentTypes?: string[];

--- a/packages/blob/src/client.ts
+++ b/packages/blob/src/client.ts
@@ -97,7 +97,7 @@ async function importKey(token?: string): Promise<CryptoKey> {
   );
 }
 
-export async function signPayload(
+async function signPayload(
   payload: string,
   token: string
 ): Promise<string | undefined> {

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -17,7 +17,8 @@ describe('blob client', () => {
   let mockClient: Interceptable;
 
   beforeEach(() => {
-    process.env.BLOB_READ_WRITE_TOKEN = 'TEST_TOKEN';
+    process.env.BLOB_READ_WRITE_TOKEN =
+      'vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678';
     const mockAgent = new MockAgent();
     mockAgent.disableNetConnect();
     setGlobalDispatcher(mockAgent);
@@ -54,7 +55,9 @@ describe('blob client', () => {
       expect(path).toEqual(
         '/?url=https%3A%2F%2FstoreId.public.blob.vercel-storage.com%2Ffoo-id.txt'
       );
-      expect(headers.authorization).toEqual('Bearer TEST_TOKEN');
+      expect(headers.authorization).toEqual(
+        'Bearer vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678'
+      );
     });
 
     it('should return null when calling `head()` with an url that does not exist', async () => {
@@ -133,7 +136,9 @@ describe('blob client', () => {
       ).resolves.toBeUndefined();
 
       expect(path).toEqual('/delete');
-      expect(headers.authorization).toEqual('Bearer TEST_TOKEN');
+      expect(headers.authorization).toEqual(
+        'Bearer vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678'
+      );
       expect(body).toMatchInlineSnapshot(
         `"{"urls":["https://storeId.public.blob.vercel-storage.com/foo-id.txt"]}"`
       );
@@ -162,7 +167,9 @@ describe('blob client', () => {
         ])
       ).resolves.toBeUndefined();
       expect(path).toEqual('/delete');
-      expect(headers.authorization).toEqual('Bearer TEST_TOKEN');
+      expect(headers.authorization).toEqual(
+        'Bearer vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678'
+      );
       expect(body).toMatchInlineSnapshot(
         `"{"urls":["https://storeId.public.blob.vercel-storage.com/foo-id1.txt","https://storeId.public.blob.vercel-storage.com/foo-id2.txt"]}"`
       );
@@ -248,7 +255,9 @@ describe('blob client', () => {
         }
       `);
       expect(path).toBe('/?limit=10&prefix=test-prefix&cursor=cursor-abc');
-      expect(headers.authorization).toEqual('Bearer TEST_TOKEN');
+      expect(headers.authorization).toEqual(
+        'Bearer vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678'
+      );
     });
 
     it('should throw when calling `list()` with an invalid token', async () => {

--- a/packages/blob/src/index.ts
+++ b/packages/blob/src/index.ts
@@ -10,18 +10,12 @@ import {
   getApiVersionHeader,
   getTokenFromOptionsOrEnv,
 } from './helpers';
+import type { PutCommandOptions } from './put';
 import { createPutMethod } from './put';
 
 // expose the BlobError types
 export { BlobAccessError, BlobError, BlobUnknownError } from './helpers';
 export type { PutBlobResult } from './put';
-
-export interface PutCommandOptions extends BlobCommandOptions {
-  access: 'public';
-  contentType?: string;
-  addRandomSuffix?: boolean;
-  cacheControlMaxAge?: number;
-}
 
 // vercelBlob.put()
 export const put = createPutMethod<PutCommandOptions>({

--- a/packages/blob/src/put.ts
+++ b/packages/blob/src/put.ts
@@ -71,6 +71,7 @@ export function createPutMethod<
       throw new BlobError('missing options, see usage');
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Runtime check for DX.
     if (options.access !== 'public') {
       throw new BlobError('access must be "public"');
     }

--- a/packages/blob/src/put.ts
+++ b/packages/blob/src/put.ts
@@ -2,6 +2,7 @@ import type { Readable } from 'node:stream';
 import type { BodyInit } from 'undici';
 import { fetch } from 'undici';
 import type { ClientPutCommandOptions } from './client';
+import type { BlobCommandOptions } from './helpers';
 import {
   BlobAccessError,
   BlobUnknownError,
@@ -10,7 +11,13 @@ import {
   getTokenFromOptionsOrEnv,
   BlobError,
 } from './helpers';
-import { type PutCommandOptions } from '.';
+
+export interface PutCommandOptions extends BlobCommandOptions {
+  access: 'public';
+  contentType?: string;
+  addRandomSuffix?: boolean;
+  cacheControlMaxAge?: number;
+}
 
 const putOptionHeaderMap = {
   cacheControlMaxAge: 'x-cache-control-max-age',
@@ -64,7 +71,6 @@ export function createPutMethod<
       throw new BlobError('missing options, see usage');
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Runtime check for DX
     if (options.access !== 'public') {
       throw new BlobError('access must be "public"');
     }

--- a/packages/blob/tsup.config.js
+++ b/packages/blob/tsup.config.js
@@ -5,6 +5,7 @@ export default defineConfig({
   entry: ['src/index.ts', 'src/client.ts'],
   format: ['esm', 'cjs'],
   splitting: true,
+  target: 'es2019',
   sourcemap: true,
   minify: false,
   clean: true,

--- a/test/next/src/app/vercel/blob/handle-blob-upload.ts
+++ b/test/next/src/app/vercel/blob/handle-blob-upload.ts
@@ -46,17 +46,17 @@ export async function handleUploadHandler(
             'image/gif',
             'text/plain',
           ],
-          metadata: JSON.stringify({
+          tokenPayload: JSON.stringify({
             userId: user?.id,
           }),
         };
       },
       // eslint-disable-next-line @typescript-eslint/require-await -- [@vercel/style-guide@5 migration]
-      onUploadCompleted: async ({ blob, metadata }) => {
+      onUploadCompleted: async ({ blob, tokenPayload }) => {
         // eslint-disable-next-line no-console -- [@vercel/style-guide@5 migration]
-        console.log('Upload completed', blob, metadata);
+        console.log('Upload completed', blob, tokenPayload);
         try {
-          //   await db.update({ avatar: blob.url, userId: metadata.userId });
+          //   await db.update({ avatar: blob.url, userId: tokenPayload.userId });
         } catch (error) {
           throw new Error('Could not update user');
         }

--- a/test/next/src/pages/api/vercel/blob/pages/handle-blob-upload-serverless.ts
+++ b/test/next/src/pages/api/vercel/blob/pages/handle-blob-upload-serverless.ts
@@ -29,17 +29,17 @@ export default async function handleBody(
             'image/gif',
             'text/plain',
           ],
-          metadata: JSON.stringify({
+          tokenPayload: JSON.stringify({
             userId: 'user.id',
           }),
         };
       },
       // eslint-disable-next-line @typescript-eslint/require-await -- [@vercel/style-guide@5 migration]
-      onUploadCompleted: async ({ blob, metadata }) => {
+      onUploadCompleted: async ({ blob, tokenPayload }) => {
         // eslint-disable-next-line no-console -- [@vercel/style-guide@5 migration]
-        console.log('Upload completed', blob, metadata);
+        console.log('Upload completed', blob, tokenPayload);
         try {
-          //   await db.update({ avatar: blob.url, userId: metadata.userId });
+          //   await db.update({ avatar: blob.url, userId: tokenPayload.userId });
         } catch (error) {
           throw new Error('Could not update user');
         }


### PR DESCRIPTION
This PR allows `clientPayload` during `upload,` so you can attach
metadata to the file uploaded to Vercel Blob. This metadata will be sent as
`tokenPayload` by default in uploading completed callbacks. And you can also enrich
it/configure it/verify it.

Usage:
```ts
// client.ts
import { upload } from '@vercel/blob/client';

upload(
  'file.txt',
  {
    access: 'public',
    handleUploadUrl: '/api/upload',
    clientPayload: JSON.stringify({ postId: 123 })
  }
);
```

```ts
const jsonResponse = await handleUpload({
  body,
  request,
  onBeforeGenerateToken: async (pathname, clientPayload) => {

    return {
       tokenPayload: clientPayload // this is the default, ideally you would verify the clientPayload (format, authorization) before generating the token, so no files are uploaded without first verifying the client claims
    };
  },
  onUploadCompleted: async ({ blob, tokenPayload }) => {
    console.log('blob upload completed', blob, tokenPayload);
  }
});
```

An example use-case of this feature would be to allow editing the images of a
blog post. To do so you would use `clientPayload: JSON.stringify({ postId: 345
})` in the browser. Then, either in onBeforeGenerateToken or in onUploadCompleted
you would verify that the client making the call is allowed to modify this
postId (authorization) and update your database accordingly.

BREAKING CHANGES:
- `metadata` in `onBeforeGenerateToken` and `onUploadCompleted` has been renamed to `tokenPayload`

TODO before release:
- [ ] modify edge-functions to accept tokenPayload AND metadata
- [ ] test on staging for real
- [ ] update front PR documentation