### PR TITLE
add stale-if-error semantics

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "canary",
   "initialVersions": {
     "@vercel/blob": "0.11.0",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,16 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@vercel/blob": "0.11.0",
+    "@vercel/edge-config": "0.3.0",
+    "@vercel/edge-config-fs": "0.1.0",
+    "@vercel/kv": "0.2.2",
+    "@vercel/postgres": "0.4.1",
+    "@vercel/postgres-kysely": "0.4.1",
+    "vercel-storage-integration-test-suite": "0.1.18",
+    "eslint-config-custom": "0.0.0",
+    "tsconfig": "0.0.0"
+  },
+  "changesets": []
+}

--- a/.changeset/rotten-mugs-listen.md
+++ b/.changeset/rotten-mugs-listen.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': minor
+---
+
+add stale-while-revalidate semantics

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -70,9 +70,12 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
+      - name: Add SHORT_SHA env property with commit short sha
+        run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
+
       - name: Create Snapshot Release
         run: |
-          pnpm changeset version --snapshot ${{ github.sha }}
+          pnpm changeset version --snapshot ${SHORT_SHA}
           pnpm changeset publish --no-git-tag --tag snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/edge-config/jest/setup.js
+++ b/packages/edge-config/jest/setup.js
@@ -2,3 +2,11 @@ require('jest-fetch-mock').enableMocks();
 
 process.env.EDGE_CONFIG = 'https://edge-config.vercel.com/ecfg-1?token=token-1';
 process.env.VERCEL_ENV = 'test';
+
+// Adds a DOMException polyfill
+//
+// The polyfill is necessary to use AbortController in node v16 by our tests.
+// AbortController itself is used when calling fetchMock.mockAbortOnce().
+if (!globalThis.DOMException) {
+  require('node-domexception');
+}

--- a/packages/edge-config/package.json
+++ b/packages/edge-config/package.json
@@ -53,6 +53,7 @@
     "eslint-config-custom": "workspace:*",
     "jest": "29.6.4",
     "jest-fetch-mock": "3.0.3",
+    "node-domexception": "2.0.1",
     "prettier": "2.8.8",
     "ts-jest": "29.1.1",
     "tsconfig": "workspace:*",

--- a/packages/edge-config/src/index.common.test.ts
+++ b/packages/edge-config/src/index.common.test.ts
@@ -220,8 +220,7 @@ describe('stale-if-error semantics', () => {
 
       await expect(edgeConfig.get('foo')).resolves.toEqual('bar');
 
-      // the server would not actually send a response body the second time
-      // as the etag matches
+      // pretend the server returned a 502 without any response body
       fetchMock.mockResponseOnce('', { status: 502 });
 
       // second call should reuse earlier response
@@ -262,9 +261,7 @@ describe('stale-if-error semantics', () => {
 
       await expect(edgeConfig.get('foo')).resolves.toEqual('bar');
 
-      // the server would not actually send a response body the second time
-      // as the etag matches
-      // fetchMock.mockResponseOnce('', { status: 502 });
+      // pretend there was a network error which led to fetch throwing
       fetchMock.mockAbortOnce();
 
       // second call should reuse earlier response

--- a/packages/edge-config/src/index.common.test.ts
+++ b/packages/edge-config/src/index.common.test.ts
@@ -85,6 +85,7 @@ describe('when running without lambda layer or via edge function', () => {
               Authorization: 'Bearer token-2',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -109,6 +110,7 @@ describe('when running without lambda layer or via edge function', () => {
               Authorization: 'Bearer token-2',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -132,6 +134,7 @@ describe('when running without lambda layer or via edge function', () => {
               Authorization: 'Bearer token-2',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -141,7 +144,7 @@ describe('when running without lambda layer or via edge function', () => {
   });
 });
 
-describe('etags and if-none-match', () => {
+describe('etags and If-None-Match', () => {
   const modifiedConnectionString =
     'https://edge-config.vercel.com/ecfg-2?token=token-2';
   const modifiedBaseUrl = 'https://edge-config.vercel.com/ecfg-2';
@@ -180,6 +183,7 @@ describe('etags and if-none-match', () => {
             Authorization: 'Bearer token-2',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         }
@@ -191,7 +195,8 @@ describe('etags and if-none-match', () => {
             Authorization: 'Bearer token-2',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
-            'if-none-match': 'a',
+            'cache-control': 'stale-if-error=604800',
+            'If-None-Match': 'a',
           }),
           cache: 'no-store',
         }
@@ -234,6 +239,7 @@ describe('stale-if-error semantics', () => {
             Authorization: 'Bearer token-2',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         }
@@ -245,7 +251,8 @@ describe('stale-if-error semantics', () => {
             Authorization: 'Bearer token-2',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
-            'if-none-match': 'a',
+            'cache-control': 'stale-if-error=604800',
+            'If-None-Match': 'a',
           }),
           cache: 'no-store',
         }
@@ -275,6 +282,7 @@ describe('stale-if-error semantics', () => {
             Authorization: 'Bearer token-2',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         }
@@ -286,7 +294,8 @@ describe('stale-if-error semantics', () => {
             Authorization: 'Bearer token-2',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
-            'if-none-match': 'a',
+            'cache-control': 'stale-if-error=604800',
+            'If-None-Match': 'a',
           }),
           cache: 'no-store',
         }
@@ -338,6 +347,7 @@ describe('connectionStrings', () => {
                 Authorization: 'Bearer token-2',
                 'x-edge-config-vercel-env': 'test',
                 'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+                'cache-control': 'stale-if-error=604800',
               }),
               cache: 'no-store',
             }

--- a/packages/edge-config/src/index.edge.test.ts
+++ b/packages/edge-config/src/index.edge.test.ts
@@ -31,6 +31,7 @@ describe('default Edge Config', () => {
         Authorization: 'Bearer token-1',
         'x-edge-config-vercel-env': 'test',
         'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+        'cache-control': 'stale-if-error=604800',
       }),
       cache: 'no-store',
     });
@@ -51,6 +52,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -86,6 +88,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -117,6 +120,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -140,6 +144,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -163,6 +168,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -184,6 +190,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });
@@ -207,6 +214,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -238,6 +246,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -259,6 +268,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });
@@ -279,6 +289,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });
@@ -302,6 +313,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -338,6 +350,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -370,6 +383,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -391,6 +405,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });
@@ -411,6 +426,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });
@@ -429,6 +445,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });
@@ -449,6 +466,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });

--- a/packages/edge-config/src/index.node.test.ts
+++ b/packages/edge-config/src/index.node.test.ts
@@ -48,6 +48,7 @@ describe('default Edge Config', () => {
         Authorization: 'Bearer token-1',
         'x-edge-config-vercel-env': 'test',
         'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+        'cache-control': 'stale-if-error=604800',
       }),
       cache: 'no-store',
     });
@@ -68,6 +69,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -103,6 +105,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -134,6 +137,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -157,6 +161,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -180,6 +185,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -201,6 +207,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });
@@ -224,6 +231,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -255,6 +263,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -276,6 +285,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });
@@ -296,6 +306,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });
@@ -319,6 +330,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -355,6 +367,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -387,6 +400,7 @@ describe('default Edge Config', () => {
               Authorization: 'Bearer token-1',
               'x-edge-config-vercel-env': 'test',
               'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+              'cache-control': 'stale-if-error=604800',
             }),
             cache: 'no-store',
           }
@@ -408,6 +422,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });
@@ -428,6 +443,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });
@@ -446,6 +462,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });
@@ -466,6 +483,7 @@ describe('default Edge Config', () => {
             Authorization: 'Bearer token-1',
             'x-edge-config-vercel-env': 'test',
             'x-edge-config-sdk': `@vercel/edge-config@${sdkVersion}`,
+            'cache-control': 'stale-if-error=604800',
           }),
           cache: 'no-store',
         });

--- a/packages/edge-config/src/utils/fetch-with-cached-response.test.ts
+++ b/packages/edge-config/src/utils/fetch-with-cached-response.test.ts
@@ -1,10 +1,17 @@
 import fetchMock from 'jest-fetch-mock';
-import { fetchWithCachedResponse, cache } from './fetch-with-cached-response';
+import {
+  createFetchWithCachedResponse,
+  cache,
+} from './fetch-with-cached-response';
 
 describe('cache', () => {
   it('should be an object', () => {
     expect(typeof cache).toEqual('object');
   });
+});
+
+const fetchWithCachedResponse = createFetchWithCachedResponse({
+  staleIfError: Infinity,
 });
 
 describe('fetchWithCachedResponse', () => {

--- a/packages/edge-config/src/utils/fetch-with-cached-response.test.ts
+++ b/packages/edge-config/src/utils/fetch-with-cached-response.test.ts
@@ -1,17 +1,10 @@
 import fetchMock from 'jest-fetch-mock';
-import {
-  createFetchWithCachedResponse,
-  cache,
-} from './fetch-with-cached-response';
+import { fetchWithCachedResponse, cache } from './fetch-with-cached-response';
 
 describe('cache', () => {
   it('should be an object', () => {
     expect(typeof cache).toEqual('object');
   });
-});
-
-const fetchWithCachedResponse = createFetchWithCachedResponse({
-  staleIfError: Infinity,
 });
 
 describe('fetchWithCachedResponse', () => {
@@ -31,7 +24,10 @@ describe('fetchWithCachedResponse', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith('https://example.com/api/data', {});
     expect(data1.headers).toEqual(
-      new Headers({ ETag: 'abc123', 'content-type': 'application/json' })
+      new Headers({
+        ETag: 'abc123',
+        'content-type': 'application/json',
+      })
     );
     await expect(data1.json()).resolves.toEqual({ name: 'John' });
     expect(data1.cachedResponseBody).toBeUndefined();
@@ -39,7 +35,10 @@ describe('fetchWithCachedResponse', () => {
     // Second request (should come from cache)
     fetchMock.mockResponseOnce('', {
       status: 304,
-      headers: { ETag: 'abc123', 'content-type': 'application/json' },
+      headers: {
+        ETag: 'abc123',
+        'content-type': 'application/json',
+      },
     });
     const data2 = await fetchWithCachedResponse('https://example.com/api/data');
 
@@ -57,7 +56,10 @@ describe('fetchWithCachedResponse', () => {
 
   it('should differentiate caches by authorization header', async () => {
     fetchMock.mockResponseOnce(JSON.stringify({ name: 'John' }), {
-      headers: { ETag: 'abc123', 'content-type': 'application/json' },
+      headers: {
+        ETag: 'abc123',
+        'content-type': 'application/json',
+      },
     });
 
     // First request

--- a/packages/edge-config/src/utils/fetch-with-cached-response.test.ts
+++ b/packages/edge-config/src/utils/fetch-with-cached-response.test.ts
@@ -1,6 +1,8 @@
 import fetchMock from 'jest-fetch-mock';
 import { fetchWithCachedResponse, cache } from './fetch-with-cached-response';
 
+jest.useFakeTimers();
+
 describe('cache', () => {
   it('should be an object', () => {
     expect(typeof cache).toEqual('object');
@@ -129,5 +131,95 @@ describe('fetchWithCachedResponse', () => {
 
     expect(data3).toHaveProperty('status', 304);
     expect(data3.cachedResponseBody).toEqual({ name: 'John' });
+  });
+
+  it('should respect stale-if-error on 500s', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ name: 'John' }), {
+      headers: { ETag: 'abc123', 'content-type': 'application/json' },
+    });
+
+    // First request
+    const data1 = await fetchWithCachedResponse('https://example.com/api/data');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/api/data', {});
+    expect(data1.headers).toEqual(
+      new Headers({
+        ETag: 'abc123',
+        'content-type': 'application/json',
+      })
+    );
+    await expect(data1.json()).resolves.toEqual({ name: 'John' });
+    expect(data1.cachedResponseBody).toBeUndefined();
+
+    jest.advanceTimersByTime(5000);
+
+    // Second request (should come from cache)
+    fetchMock.mockResponseOnce('', { status: 502 });
+    const data2 = await fetchWithCachedResponse(
+      'https://example.com/api/data',
+      { headers: new Headers({ 'Cache-Control': 'stale-if-error=10' }) }
+    );
+
+    jest.advanceTimersByTime(3000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(data2.headers).toEqual(
+      new Headers({
+        'content-type': 'application/json',
+        // Age is present when a cached response was served as per HTTP spec
+        // And in this case a stale-if-error cached response is being served
+        Age: '5',
+        etag: 'abc123',
+      })
+    );
+
+    expect(data2).toHaveProperty('status', 200);
+    await expect(data2.json()).resolves.toEqual({ name: 'John' });
+  });
+
+  it('should respect stale-if-error on network faults', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ name: 'John' }), {
+      headers: { ETag: 'abc123', 'content-type': 'application/json' },
+    });
+
+    // First request
+    const data1 = await fetchWithCachedResponse('https://example.com/api/data');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/api/data', {});
+    expect(data1.headers).toEqual(
+      new Headers({
+        ETag: 'abc123',
+        'content-type': 'application/json',
+      })
+    );
+    await expect(data1.json()).resolves.toEqual({ name: 'John' });
+    expect(data1.cachedResponseBody).toBeUndefined();
+
+    jest.advanceTimersByTime(5000);
+
+    // Second request (should come from cache)
+    fetchMock.mockAbortOnce();
+    const data2 = await fetchWithCachedResponse(
+      'https://example.com/api/data',
+      { headers: new Headers({ 'Cache-Control': 'stale-if-error=10' }) }
+    );
+
+    jest.advanceTimersByTime(3000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(data2.headers).toEqual(
+      new Headers({
+        'content-type': 'application/json',
+        // Age is present when a cached response was served as per HTTP spec
+        // And in this case a stale-if-error cached response is being served
+        Age: '5',
+        etag: 'abc123',
+      })
+    );
+
+    expect(data2).toHaveProperty('status', 200);
+    await expect(data2.json()).resolves.toEqual({ name: 'John' });
   });
 });

--- a/packages/edge-config/src/utils/fetch-with-cached-response.ts
+++ b/packages/edge-config/src/utils/fetch-with-cached-response.ts
@@ -19,7 +19,13 @@ function createResponse(
   cachedResponseEntry: CachedResponseEntry
 ): ResponseWithCachedResponse {
   return new Response(cachedResponseEntry.response, {
-    headers: cachedResponseEntry.headers,
+    headers: {
+      ...cachedResponseEntry.headers,
+      Age: String(
+        // age header may not be 0 when serving stale content, must be >= 1
+        Math.max(1, Math.floor((Date.now() - cachedResponseEntry.time) / 1000))
+      ),
+    },
     status: cachedResponseEntry.status,
   });
 }

--- a/packages/edge-config/src/utils/fetch-with-cached-response.ts
+++ b/packages/edge-config/src/utils/fetch-with-cached-response.ts
@@ -29,7 +29,7 @@ function createResponse(
  */
 function createHandleStaleIfError(
   cachedResponseEntry: CachedResponseEntry,
-  staleIfError: number
+  staleIfError: number | null
 ) {
   return function handleStaleIfError(
     response: ResponseWithCachedResponse
@@ -39,7 +39,8 @@ function createHandleStaleIfError(
       case 502:
       case 503:
       case 504:
-        return cachedResponseEntry.time < Date.now() + staleIfError * 1000
+        return typeof staleIfError === 'number' &&
+          cachedResponseEntry.time < Date.now() + staleIfError * 1000
           ? createResponse(cachedResponseEntry)
           : response;
       default:
@@ -53,12 +54,15 @@ function createHandleStaleIfError(
  */
 function createHandleStaleIfErrorException(
   cachedResponseEntry: CachedResponseEntry,
-  staleIfError: number
+  staleIfError: number | null
 ) {
   return function handleStaleIfError(
     reason: unknown
   ): ResponseWithCachedResponse {
-    if (cachedResponseEntry.time < Date.now() + staleIfError * 1000) {
+    if (
+      typeof staleIfError === 'number' &&
+      cachedResponseEntry.time < Date.now() + staleIfError * 1000
+    ) {
       return createResponse(cachedResponseEntry);
     }
     throw reason;
@@ -73,72 +77,71 @@ function createHandleStaleIfErrorException(
  */
 export const cache = new Map<string, CachedResponseEntry>();
 
+function extractStaleIfError(cacheControlHeader: string | null): number | null {
+  if (!cacheControlHeader) return null;
+  const matched = /stale-if-error=(?<staleIfError>\d+)/i.exec(
+    cacheControlHeader
+  );
+  return matched?.groups ? Number(matched.groups.staleIfError) : null;
+}
+
 /**
  * This is similar to fetch, but it also implements ETag semantics, and
  * it implmenets stale-if-error semantics.
  */
-export function createFetchWithCachedResponse(params: {
-  staleIfError: number;
-}): (
+export async function fetchWithCachedResponse(
   url: string,
-  options?: FetchOptions
-) => Promise<ResponseWithCachedResponse> {
-  return async function fetchWithCachedResponse(
-    url: string,
-    options: FetchOptions = {}
-  ): Promise<ResponseWithCachedResponse> {
-    const { headers: customHeaders = new Headers(), ...customOptions } =
-      options;
-    const authHeader = customHeaders.get('Authorization');
-    const cacheKey = `${url},${authHeader || ''}`;
+  options: FetchOptions = {}
+): Promise<ResponseWithCachedResponse> {
+  const { headers: customHeaders = new Headers(), ...customOptions } = options;
+  const authHeader = customHeaders.get('Authorization');
+  const cacheKey = `${url},${authHeader || ''}`;
 
-    const cachedResponseEntry = cache.get(cacheKey);
+  const cachedResponseEntry = cache.get(cacheKey);
 
-    if (cachedResponseEntry) {
-      const { etag, response: cachedResponse } = cachedResponseEntry;
-      const headers = new Headers(customHeaders);
-      headers.set('If-None-Match', etag);
+  if (cachedResponseEntry) {
+    const { etag, response: cachedResponse } = cachedResponseEntry;
+    const headers = new Headers(customHeaders);
+    headers.set('If-None-Match', etag);
 
-      const res: ResponseWithCachedResponse = await fetch(url, {
-        ...customOptions,
-        headers,
-      }).then(
-        createHandleStaleIfError(cachedResponseEntry, params.staleIfError),
-        createHandleStaleIfErrorException(
-          cachedResponseEntry,
-          params.staleIfError
-        )
-      );
+    const staleIfError = extractStaleIfError(headers.get('Cache-Control'));
 
-      if (res.status === 304) {
-        res.cachedResponseBody = JSON.parse(cachedResponse);
-        return res;
-      }
+    const res: ResponseWithCachedResponse = await fetch(url, {
+      ...customOptions,
+      headers,
+    }).then(
+      createHandleStaleIfError(cachedResponseEntry, staleIfError),
+      createHandleStaleIfErrorException(cachedResponseEntry, staleIfError)
+    );
 
-      const newETag = res.headers.get('ETag');
-      if (res.ok && newETag)
-        cache.set(cacheKey, {
-          etag: newETag,
-          response: await res.clone().text(),
-          headers: Object.fromEntries(res.headers.entries()),
-          status: res.status,
-          time: Date.now(),
-        });
+    if (res.status === 304) {
+      res.cachedResponseBody = JSON.parse(cachedResponse);
       return res;
     }
 
-    const res = await fetch(url, options);
-    const etag = res.headers.get('ETag');
-    if (res.ok && etag) {
+    const newETag = res.headers.get('ETag');
+    if (res.ok && newETag)
       cache.set(cacheKey, {
-        etag,
+        etag: newETag,
         response: await res.clone().text(),
         headers: Object.fromEntries(res.headers.entries()),
         status: res.status,
         time: Date.now(),
       });
-    }
-
     return res;
-  };
+  }
+
+  const res = await fetch(url, options);
+  const etag = res.headers.get('ETag');
+  if (res.ok && etag) {
+    cache.set(cacheKey, {
+      etag,
+      response: await res.clone().text(),
+      headers: Object.fromEntries(res.headers.entries()),
+      status: res.status,
+      time: Date.now(),
+    });
+  }
+
+  return res;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       jest-fetch-mock:
         specifier: 3.0.3
         version: 3.0.3
+      node-domexception:
+        specifier: 2.0.1
+        version: 2.0.1
       prettier:
         specifier: 2.8.8
         version: 2.8.8
@@ -1185,6 +1188,7 @@ packages:
     dependencies:
       eslint: 8.40.0
       eslint-visitor-keys: 3.4.3
+    dev: false
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.48.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
@@ -1198,6 +1202,7 @@ packages:
   /@eslint-community/regexpp@4.5.0:
     resolution: {integrity: sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: false
 
   /@eslint-community/regexpp@4.8.0:
     resolution: {integrity: sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==}
@@ -1218,6 +1223,7 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@eslint/eslintrc@2.1.2:
     resolution: {integrity: sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==}
@@ -1238,6 +1244,7 @@ packages:
   /@eslint/js@8.40.0:
     resolution: {integrity: sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
 
   /@eslint/js@8.48.0:
     resolution: {integrity: sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==}
@@ -1262,6 +1269,7 @@ packages:
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@humanwhocodes/module-importer@1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -2011,7 +2019,6 @@ packages:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/eslint-plugin@6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.48.0)(typescript@5.2.2):
     resolution: {integrity: sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==}
@@ -2059,6 +2066,7 @@ packages:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@typescript-eslint/parser@6.5.0(eslint@8.48.0)(typescript@5.0.4):
     resolution: {integrity: sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==}
@@ -2079,7 +2087,6 @@ packages:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/parser@6.5.0(eslint@8.48.0)(typescript@5.2.2):
     resolution: {integrity: sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==}
@@ -2153,7 +2160,6 @@ packages:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/type-utils@6.5.0(eslint@8.48.0)(typescript@5.2.2):
     resolution: {integrity: sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==}
@@ -2241,7 +2247,6 @@ packages:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/typescript-estree@6.5.0(typescript@5.2.2):
     resolution: {integrity: sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==}
@@ -2301,7 +2306,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
 
   /@typescript-eslint/utils@5.59.1(eslint@8.48.0)(typescript@5.2.2):
     resolution: {integrity: sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==}
@@ -2339,7 +2343,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
 
   /@typescript-eslint/utils@6.5.0(eslint@8.48.0)(typescript@5.2.2):
     resolution: {integrity: sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==}
@@ -3672,7 +3675,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-typescript@3.6.0)(eslint@8.40.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.5.0)(eslint-import-resolver-typescript@3.6.0)(eslint@8.48.0)
 
   /eslint-import-resolver-node@0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
@@ -3728,6 +3731,7 @@ packages:
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
+    dev: false
 
   /eslint-import-resolver-typescript@3.6.0(@typescript-eslint/parser@6.5.0)(eslint-plugin-import@2.28.1)(eslint@8.48.0):
     resolution: {integrity: sha512-QTHR9ddNnn35RTxlaEnx2gCxqFlF2SEN0SE2d17SqwyM7YOSI2GHWRYp5BiRkObTUNYPupC/3Fq2a0PpT+EKpg==}
@@ -3809,6 +3813,7 @@ packages:
       eslint-import-resolver-typescript: 3.6.0(@typescript-eslint/parser@5.59.1)(eslint-plugin-import@2.28.1)(eslint@8.40.0)
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.5.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.6.0)(eslint@8.48.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
@@ -3831,7 +3836,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.5.0(eslint@8.48.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.48.0)(typescript@5.0.4)
       debug: 3.2.7
       eslint: 8.48.0
       eslint-import-resolver-node: 0.3.7
@@ -3878,7 +3883,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.40.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.6.0)(eslint@8.40.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.1)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -3926,6 +3931,7 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: false
 
   /eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.5.0)(eslint-import-resolver-typescript@3.6.0)(eslint@8.48.0):
     resolution: {integrity: sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==}
@@ -3937,7 +3943,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.5.0(eslint@8.48.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.48.0)(typescript@5.0.4)
       array-includes: 3.1.6
       array.prototype.findlastindex: 1.2.2
       array.prototype.flat: 1.3.1
@@ -4003,7 +4009,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
 
   /eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.5.0)(eslint@8.48.0)(jest@29.6.4)(typescript@5.2.2):
     resolution: {integrity: sha512-sRLlSCpICzWuje66Gl9zvdF6mwD5X86I4u55hJyFBsxYOsBCmT5+kSUjf+fkFWVMMgpzNEupjW8WzUqi83hJAQ==}
@@ -4098,7 +4103,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.48.0
-      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@6.5.0)(eslint@8.48.0)(jest@29.6.4)(typescript@5.2.2)
+      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@6.5.0)(eslint@8.48.0)(jest@29.6.4)(typescript@5.0.4)
 
   /eslint-plugin-react-hooks@4.6.0(eslint@8.40.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
@@ -4302,6 +4307,7 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
+    dev: false
 
   /eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
@@ -4327,6 +4333,7 @@ packages:
   /eslint-visitor-keys@3.4.1:
     resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
 
   /eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
@@ -4379,6 +4386,7 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /eslint@8.48.0:
     resolution: {integrity: sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==}
@@ -4432,6 +4440,7 @@ packages:
       acorn: 8.9.0
       acorn-jsx: 5.3.2(acorn@8.9.0)
       eslint-visitor-keys: 3.4.3
+    dev: false
 
   /espree@9.6.0:
     resolution: {integrity: sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==}
@@ -4440,6 +4449,7 @@ packages:
       acorn: 8.9.0
       acorn-jsx: 5.3.2(acorn@8.9.0)
       eslint-visitor-keys: 3.4.3
+    dev: false
 
   /espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -5860,6 +5870,7 @@ packages:
 
   /js-sdsl@4.4.0:
     resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
+    dev: false
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -6359,6 +6370,11 @@ packages:
       - babel-plugin-macros
     dev: false
 
+  /node-domexception@2.0.1:
+    resolution: {integrity: sha512-M85rnSC7WQ7wnfQTARPT4LrK7nwCHLdDFOCcItZMhTQjyCebJH8GciKqYJNgaOFZs9nFmTmd/VMyi3OW5jA47w==}
+    engines: {node: '>=16'}
+    dev: true
+
   /node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -6578,6 +6594,7 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.3
+    dev: false
 
   /optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
@@ -7692,7 +7709,6 @@ packages:
       typescript: '>=4.2.0'
     dependencies:
       typescript: 5.0.4
-    dev: true
 
   /ts-api-utils@1.0.2(typescript@5.2.2):
     resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
@@ -8276,6 +8292,7 @@ packages:
   /word-wrap@1.2.3:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
     engines: {node: '>=0.10.0'}
+    dev: false
 
   /wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}


### PR DESCRIPTION
Adds stale-if-error semantics to the Edge Config SDK.

This will reuse the previous response whenever the response to an Edge Config read has status code 500, 502, 503 or 504. This list of codes to apply stale-if-error semantics is from [Cache Control on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control).It will also reuse the previous response whenever fetch throws.

If no previous response exists the behavior is unchanged and the SDK will still throw.

There is currently no max age for stale responses. 

To decide:
- whether we want to introduce a maxAge / ttl for stale-if-error responses -> Yes
- whether we want to make stale-if-error behavior configurable via options in `createClient(process.env.EDGE_CONFIG, options)` -> Yes
