### PR TITLE
avoid using changesets-bot for release-snapshots action

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -30,11 +30,9 @@ jobs:
         run: pnpm install
 
       - name: Create Snapshot Release
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          version: pnpm changeset version --snapshot ${{ github.sha }}
-          publish: pnpm changeset publish --tag snapshot
+        run: |
+          pnpm changeset version --snapshot ${{ github.sha }}
+          pnpm changeset publish --tag snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Create Snapshot Release
         run: |
           pnpm changeset version --snapshot ${{ github.sha }}
-          pnpm changeset publish --tag snapshot
+          pnpm changeset publish --no-git-tag --tag snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}


### PR DESCRIPTION
When using the changesets/action the flow ends up making a pull request, but we want it to release immediately while also discarding any changes `pnpm changeset version` results in.