### PR TITLE
disable calculated versions

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,6 +9,6 @@
   "updateInternalDependencies": "patch",
   "ignore": [],
   "snapshot": {
-    "useCalculatedVersion": true
+    "useCalculatedVersion": false
   }
 }


### PR DESCRIPTION
When turning this option off all snapshot releases will start with `0.0.0-` instead of using a calculated version.

I'm not sure what we prefer, but opening the PR now so we can decide.

```diff
-0.4.0-579bd13f016c7de43a2830340634b3948db358b6-20230913164912
+0.0.0-579bd13f016c7de43a2830340634b3948db358b6-20230913164912
```