### PR TITLE
use short sha as snapshot

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -70,9 +70,12 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
+      - name: Add SHORT_SHA env property with commit short sha
+        run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
+
       - name: Create Snapshot Release
         run: |
-          pnpm changeset version --snapshot ${{ github.sha }}
+          pnpm changeset version --snapshot ${SHORT_SHA}
           pnpm changeset publish --no-git-tag --tag snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Instead of generating long versions this will generate versions with the shorter commit sha

```diff
-0.4.0-579bd13f016c7de43a2830340634b3948db358b6-20230913164912
+0.4.0-579bd13-20230913164912
```