### PR TITLE
fix(Blob): Handle old module resolution types resolution

### DIFF
--- a/packages/blob/client.ts
+++ b/packages/blob/client.ts
@@ -1,4 +1,0 @@
-// This file is only used by the testing suite of the repository
-// Without it then the pnpm workspace setup + Next.js can't find
-// import { ... } from '@vercel/blob/client';
-export * from './src/client';

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -30,6 +30,16 @@
     "crypto": "./dist/crypto-browser.js"
   },
   "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      ".": [
+        "dist/index.d.ts"
+      ],
+      "client": [
+        "dist/client.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/blob/tsconfig.json
+++ b/packages/blob/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "tsconfig/base.json",
-  "include": ["src", "client.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
Before this commit, JavaScript projects, or TypeScript projects where the moduleResolution setting was either undefined (= default to node10) or defined but not part of node16 or nodenext would fail to properly autocomplete types for import { upload } from '@vercel/blob/client'. As `/client` only exists when the module resolution supports package.json `exports`. In all other situations you need to configure `typesVersions` or create a folder to mimick the import.

This took me ages to solve, see https://antfu.me/posts/types-for-sub-modules