### PR TITLE
support internal & external connection strings in parseConnectionString

### DIFF
--- a/.changeset/chatty-buses-smile.md
+++ b/.changeset/chatty-buses-smile.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': patch
+---
+
+make parseConnectionString parse both internal and external connection strings

--- a/packages/edge-config/src/index.common.test.ts
+++ b/packages/edge-config/src/index.common.test.ts
@@ -34,14 +34,46 @@ describe('parseConnectionString', () => {
     ).toBeNull();
   });
 
-  it('should return the id and token when a valid Connection String is given', () => {
+  it('should return the id and token when a valid internal Connection String is given', () => {
     expect(
       pkg.parseConnectionString(
         'https://edge-config.vercel.com/ecfg_cljia81u2q1gappdgptj881dwwtc?token=00000000-0000-0000-0000-000000000000'
       )
     ).toEqual({
+      baseUrl:
+        'https://edge-config.vercel.com/ecfg_cljia81u2q1gappdgptj881dwwtc',
       id: 'ecfg_cljia81u2q1gappdgptj881dwwtc',
       token: '00000000-0000-0000-0000-000000000000',
+      type: 'vercel',
+      version: '1',
+    });
+  });
+
+  it('should return the id and token when a valid external Connection String is given using pathname', () => {
+    expect(
+      pkg.parseConnectionString(
+        'https://example.com/ecfg_cljia81u2q1gappdgptj881dwwtc?token=00000000-0000-0000-0000-000000000000'
+      )
+    ).toEqual({
+      id: 'ecfg_cljia81u2q1gappdgptj881dwwtc',
+      token: '00000000-0000-0000-0000-000000000000',
+      version: '1',
+      type: 'external',
+      baseUrl: 'https://example.com/ecfg_cljia81u2q1gappdgptj881dwwtc',
+    });
+  });
+
+  it('should return the id and token when a valid external Connection String is given using search params', () => {
+    expect(
+      pkg.parseConnectionString(
+        'https://example.com/?id=ecfg_cljia81u2q1gappdgptj881dwwtc&token=00000000-0000-0000-0000-000000000000'
+      )
+    ).toEqual({
+      id: 'ecfg_cljia81u2q1gappdgptj881dwwtc',
+      token: '00000000-0000-0000-0000-000000000000',
+      baseUrl: 'https://example.com/',
+      type: 'external',
+      version: '1',
     });
   });
 });


### PR DESCRIPTION
There are two types of connection strings for Edge Config:
- internal (hosted by Vercel)
  - `https://edge-config.vercel.com/<edgeConfigId>?token=<token>`
- external (hosted outside of Vercel)
  - `https://example.com/?id=<edgeConfigId>&token=<token>`
  - `https://example.com/<edgeConfigId>?token=<token>`

Vercel only optimized the internal Edge Configs. We offer the external connection string type for testing and debugging purposes.

Until now `parseConnectionString` would only parse internal connection strings. From now on it will also parse external connection strings.

The return value was further extended from `{ id: string, token: string }` to

```ts
type Connection =
  | {
      baseUrl: string;
      id: string;
      token: string;
      version: string;
      type: 'vercel';
    }
  | {
      baseUrl: string;
      id: string;
      token: string;
      version: string;
      type: 'external';
    };
```
