### PR TITLE
Remove types field in package.json files

### DIFF
--- a/.changeset/sweet-emus-rhyme.md
+++ b/.changeset/sweet-emus-rhyme.md
@@ -1,0 +1,9 @@
+---
+'@vercel/postgres-kysely': patch
+'@vercel/edge-config': patch
+'@vercel/postgres': patch
+'@vercel/blob': patch
+'@vercel/kv': patch
+---
+
+Removed `"types"` field from package.json to support `"moduleResolution": "Node16"`

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -27,7 +27,6 @@
     "undici": "./dist/undici-browser.js",
     "crypto": "./dist/crypto-browser.js"
   },
-  "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
       "client": [

--- a/packages/edge-config/package.json
+++ b/packages/edge-config/package.json
@@ -12,11 +12,11 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
-    "types": "./dist/index.d.ts",
     "import": "./dist/index.js",
     "require": "./dist/index.cjs"
   },
-  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -13,7 +13,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": {
         "node": "./dist/index.js",
         "default": "./dist/index.js"
@@ -26,7 +25,6 @@
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/postgres-kysely/package.json
+++ b/packages/postgres-kysely/package.json
@@ -12,7 +12,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": {
         "edge-light": "./dist/index.js",
         "node": "./dist/index.js",
@@ -27,11 +26,8 @@
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "files": [
-    "dist/*.js",
-    "dist/*.cjs",
-    "dist/*.d.ts"
+    "dist"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -12,7 +12,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": {
         "edge-light": "./dist/index.js",
         "node": "./dist/index-node.js",
@@ -27,11 +26,8 @@
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "files": [
-    "dist/*.js",
-    "dist/*.cjs",
-    "dist/*.d.ts"
+    "dist"
   ],
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
The changes here are originally from https://github.com/vercel/storage/pull/314. The goal of this PR is to figure out whether our CI would succeed with these changes, as we seem unable to run CI on changes by external contributors currently.