### PR TITLE
feat(blob): add copy method

### DIFF
--- a/.changeset/breezy-hats-press.md
+++ b/.changeset/breezy-hats-press.md
@@ -1,0 +1,5 @@
+---
+"@vercel/blob": minor
+---
+
+Add copy method to @vercel/blob package. This method offers the functionality to copy an existing blob file to a new path inside the blob store. #419

--- a/packages/blob/README.md
+++ b/packages/blob/README.md
@@ -98,6 +98,36 @@ async function list(options?: {
 }> {}
 ```
 
+### copy(fromUrl, toPathname, options)
+
+Copy an existing blob to a new location in the store.
+
+The `contentType` and `cacheControlMaxAge` will not be copied from the source blob. If the values should be carried over to the copy, they need to be defined again in the options object.
+
+Contrary to `put()`, `addRandomSuffix` is false by default. This means no automatic random id suffix is added to your blob url, unless you pass `addRandomSuffix: true`. This also means `copy()` overwrites files per default, if the operation targets a pathname that already exists.
+
+```ts
+async function copy(
+  fromUrl: string,
+  toPathname: string,
+  options: {
+    access: 'public'; // mandatory, as we will provide private blobs in the future
+    contentType?: string; // by default inferred from pathname
+    // `token` defaults to process.env.BLOB_READ_WRITE_TOKEN on Vercel
+    // and can be configured when you connect more stores to a project
+    // or using Vercel Blob outside of Vercel
+    token?: string;
+    addRandomSuffix?: boolean; // optional, allows to enable random suffixes (defaults to `false`)
+    cacheControlMaxAge?: number; // optional, a duration in seconds to configure the edge and browser caches. Defaults to one year for browsers and 5 minutes for edge cache. Can only be configured server side (either on server side put or during client token generation). The Edge cache maximum value is 5 minutes.
+  }
+): Promise<{
+  url: string;
+  pathname: string;
+  contentType?: string;
+  contentDisposition: string;
+}> {}
+```
+
 ### client/`upload(pathname, body, options)`
 
 The `upload` method is dedicated to client uploads. It fetches a client token using the `handleUploadUrl` before uploading the blob.

--- a/packages/blob/src/copy.ts
+++ b/packages/blob/src/copy.ts
@@ -1,0 +1,71 @@
+import { fetch } from 'undici';
+import type { BlobCommandOptions } from './helpers';
+import {
+  BlobError,
+  getApiUrl,
+  getApiVersionHeader,
+  getTokenFromOptionsOrEnv,
+  validateBlobApiResponse,
+} from './helpers';
+
+export interface CopyCommandOptions extends BlobCommandOptions {
+  access: 'public';
+  addRandomSuffix?: boolean;
+  contentType?: string;
+  cacheControlMaxAge?: number;
+}
+
+export interface CopyBlobResult {
+  url: string;
+  pathname: string;
+  contentType?: string;
+  contentDisposition: string;
+}
+
+/**
+ * Copy blob to another location in your store.
+ * @param fromUrl - The blob URL to copy. You can only copy blobs that are in the store, that your 'BLOB_READ_WRITE_TOKEN' has access to.
+ * @param toPathname - The pathname to copy the blob to. This includes the filename.
+ * @param options - Additional options. The copy method will not preserve any metadata configuration (e.g.: 'cacheControlMaxAge') of the source blob. If you want to copy the metadata, you need to define it here again.
+ */
+export async function copy(
+  fromUrl: string,
+  toPathname: string,
+  options: CopyCommandOptions
+): Promise<CopyBlobResult> {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Runtime check for DX.
+  if (!options) {
+    throw new BlobError('missing options, see usage');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Runtime check for DX.
+  if (options.access !== 'public') {
+    throw new BlobError('access must be "public"');
+  }
+
+  const headers: Record<string, string> = {
+    ...getApiVersionHeader(),
+    authorization: `Bearer ${getTokenFromOptionsOrEnv(options)}`,
+  };
+
+  if (options.addRandomSuffix !== undefined) {
+    headers['x-add-random-suffix'] = options.addRandomSuffix ? '1' : '0';
+  }
+
+  if (options.contentType) {
+    headers['x-content-type'] = options.contentType;
+  }
+
+  if (options.cacheControlMaxAge !== undefined) {
+    headers['x-cache-control-max-age'] = options.cacheControlMaxAge.toString();
+  }
+
+  const blobApiResponse = await fetch(
+    getApiUrl(`/${toPathname}?fromUrl=${fromUrl}`),
+    { method: 'PUT', headers }
+  );
+
+  await validateBlobApiResponse(blobApiResponse);
+
+  return (await blobApiResponse.json()) as CopyBlobResult;
+}

--- a/packages/blob/src/copy.ts
+++ b/packages/blob/src/copy.ts
@@ -10,6 +10,10 @@ import {
 
 export interface CopyCommandOptions extends BlobCommandOptions {
   access: 'public';
+  /**
+   * Adds a random suffix to the filename.
+   * @defaultvalue false
+   */
   addRandomSuffix?: boolean;
   contentType?: string;
   cacheControlMaxAge?: number;

--- a/packages/blob/src/index.ts
+++ b/packages/blob/src/index.ts
@@ -161,3 +161,7 @@ function mapBlobResult(
     uploadedAt: new Date(blobResult.uploadedAt),
   };
 }
+
+// vercelBlob.copy()
+
+export { copy, type CopyBlobResult } from './copy';

--- a/packages/blob/src/put.ts
+++ b/packages/blob/src/put.ts
@@ -14,6 +14,10 @@ import {
 export interface PutCommandOptions extends BlobCommandOptions {
   access: 'public';
   contentType?: string;
+  /**
+   * Adds a random suffix to the filename.
+   * @defaultvalue true
+   */
   addRandomSuffix?: boolean;
   cacheControlMaxAge?: number;
 }

--- a/test/next/src/app/vercel/blob/script.mts
+++ b/test/next/src/app/vercel/blob/script.mts
@@ -30,6 +30,7 @@ async function run(): Promise<void> {
     fetchExample(),
     noExtensionExample(),
     weirdCharactersExample(),
+    copyTextFile(),
   ]);
 
   await Promise.all(
@@ -248,4 +249,28 @@ async function weirdCharactersExample(): Promise<string> {
     `(${Date.now() - start}ms)`
   );
   return blob.url;
+}
+
+async function copyTextFile() {
+  const start = Date.now();
+
+  const blob = await vercelBlob.put('folder/test.txt', 'Hello, world!', {
+    access: 'public',
+    contentType: 'application/json',
+    cacheControlMaxAge: 120,
+  });
+
+  const copiedBlob = await vercelBlob.copy(blob.url, 'destination/copy.txt', {
+    access: 'public',
+  });
+
+  console.log(
+    'copy blob example:',
+    copiedBlob.url,
+    `(${Date.now() - start}ms)`
+  );
+
+  await vercelBlob.del(blob.url);
+
+  return copiedBlob.url;
 }


### PR DESCRIPTION
Add copy method to @vercel/blob package. This method offers the functionality to copy an existing blob file to a new path inside the blob store. #419