### PR TITLE
read edge config using websocket while in dev

### DIFF
--- a/.changeset/curly-rabbits-change.md
+++ b/.changeset/curly-rabbits-change.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': minor
+---
+
+speed up reads during development by using a websocket subscription

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -137,7 +137,7 @@ export function createClient(
       {
         // @ts-expect-error -- this is defined in undici which is used during dev
         headers: { authorization: connection.token },
-      }
+      },
     );
 
     ws.addEventListener('message', (event) => {

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -129,6 +129,7 @@ export function createClient(
   // subscribe to changes
   if (
     process.env.NODE_ENV === 'development' &&
+    process.env.EDGE_CONFIG_DISABLE_WEBSOCKET !== '1' &&
     typeof WebSocket !== 'undefined'
   ) {
     const ws = new WebSocket(

--- a/test/next/src/app/api/vercel/edge-config/route.ts
+++ b/test/next/src/app/api/vercel/edge-config/route.ts
@@ -4,10 +4,8 @@ import { NextResponse } from 'next/server';
 export const runtime = 'edge';
 
 export async function GET(): Promise<Response> {
-  // eslint-disable-next-line no-console
-  console.time('read duration');
+  const before = Date.now();
   const keyForTest = await get<string>('keyForTest');
-  // eslint-disable-next-line no-console
-  console.timeEnd('read duration');
-  return NextResponse.json({ keyForTest });
+  const after = Date.now();
+  return NextResponse.json({ keyForTest, durationMs: after - before });
 }

--- a/test/next/src/app/api/vercel/edge-config/route.ts
+++ b/test/next/src/app/api/vercel/edge-config/route.ts
@@ -1,0 +1,13 @@
+import { get } from '@vercel/edge-config';
+import { NextResponse } from 'next/server';
+
+export const runtime = 'edge';
+
+export async function GET(): Promise<Response> {
+  // eslint-disable-next-line no-console
+  console.time('read duration');
+  const keyForTest = await get<string>('keyForTest');
+  // eslint-disable-next-line no-console
+  console.timeEnd('read duration');
+  return NextResponse.json({ keyForTest });
+}


### PR DESCRIPTION
This is a tiny optimization relevant for development only.

At the moment reading edge config in preview and production is orders of magnitude faster than reading edge config in development, since we can't apply as many optimizations when reading edge config in development.

While in development we were sending a network request on every read. This only takes ~100ms to resolve, but we can actually do better. Instead of sending a HTTP request for every read, we now initiate a websocket subscription every time an edge config client is created in development.

This optimization brings subsequent reads during development down to under 1ms, while still ensuring updates are propagated. We chose this approach over something like stale-while-revalidate as it means values will always be up to date.

The downside of this approach is that it introduces a slight divide between the logic running in development and production.

We might also want to add an option or env var to disable this optimization.