### PR TITLE
feat(kv): Switch to `default` for fetch `cache` option

### DIFF
--- a/.changeset/stale-stingrays-hunt.md
+++ b/.changeset/stale-stingrays-hunt.md
@@ -1,0 +1,12 @@
+---
+"@vercel/kv": major
+---
+
+feat(kv): Switch to `default` for fetch `cache` option
+
+BREAKING CHANGE: When using Next.js and vercel/kv, you may have kv requests and/or Next.js resources using kv being cached when you don't want them to.
+
+If that's the case, then opt-out of caching with
+https://nextjs.org/docs/app/api-reference/functions/unstable_noStore.
+
+On the contrary, if you want to enforce caching of resources you can use https://nextjs.org/docs/app/api-reference/functions/unstable_cache.

--- a/packages/kv/src/index.ts
+++ b/packages/kv/src/index.ts
@@ -77,7 +77,12 @@ export class VercelKV extends Redis {
 }
 
 export function createClient(config: RedisConfigNodejs): VercelKV {
-  return new VercelKV(config);
+  return new VercelKV({
+    // The Next.js team recommends no value or `default` for fetch requests's `cache` option
+    // upstash/redis defaults to `no-store`, so we enforce `default`
+    cache: 'default',
+    ...config,
+  });
 }
 
 // eslint-disable-next-line import/no-default-export -- [@vercel/style-guide@5 migration]


### PR DESCRIPTION
BREAKING CHANGE: When using Next.js and `vercel/kv`, you may have `kv` requests and/or Next.js resources using kv being cached when you don't want them to.

Before this commit, the default of `vercel/kv` was to avoid kv requests being cached at all costs. If you were relying on this behavior, you may have to:
- opt-out of caching with
https://nextjs.org/docs/app/api-reference/functions/unstable_noStore.
- or if you want to enforce caching of resources you can use https://nextjs.org/docs/app/api-reference/functions/unstable_cache.

Explanation: Before this commit, every `kv` fetch request was made with the `cache: no-store` option of fetch
(https://developer.mozilla.org/en-US/docs/Web/API/Request/cache).

Next.js uses the fetch cache behavior as part of data caching (https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#caching-data).

`no-store` was added by `upstash/redis` in a way to enforce `kv` queries to never be cached. But in some situations you do want them to be cached/and or the underlying Next.js resources to be cached.

Defaulting to `no-store` made it hard to opt-out of no-store
(https://github.com/vercel/storage/issues/213). The Next.js team recommended we switch to `default` and let users opt-in/out from Next.js cache.

If you're not using Next.js this should have no impact on you.

fixes #213