### PR TITLE
read edge config using swr semantics while in dev

### DIFF
--- a/.changeset/curly-rabbits-change.md
+++ b/.changeset/curly-rabbits-change.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': minor
+---
+
+speed up reads during development by using a websocket subscription

--- a/.changeset/curly-rabbits-change.md
+++ b/.changeset/curly-rabbits-change.md
@@ -2,4 +2,4 @@
 '@vercel/edge-config': minor
 ---
 
-speed up reads during development by using a swr semantics
+speed up reads during development by using swr semantics

--- a/.changeset/curly-rabbits-change.md
+++ b/.changeset/curly-rabbits-change.md
@@ -2,4 +2,4 @@
 '@vercel/edge-config': minor
 ---
 
-speed up reads during development by using a websocket subscription
+speed up reads during development by using a swr semantics

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -121,7 +121,7 @@ export function createClient(
    */
   const shouldUseSwr =
     process.env.NODE_ENV === 'development' &&
-    process.env.EDGE_CONFIG_DISABLE_WEBSOCKET !== '1';
+    process.env.EDGE_CONFIG_DISABLE_DEVELOPMENT_SWR !== '1';
 
   const api: Omit<EdgeConfigClient, 'connection'> = {
     async get<T = EdgeConfigValue>(key: string): Promise<T | undefined> {

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -137,7 +137,7 @@ export function createClient(
       {
         // @ts-expect-error -- this is defined in undici which is used during dev
         headers: { authorization: connection.token },
-      }
+      },
     );
 
     ws.addEventListener('message', (event) => {

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -129,6 +129,7 @@ export function createClient(
   // subscribe to changes
   if (
     process.env.NODE_ENV === 'development' &&
+    process.env.EDGE_CONFIG_DISABLE_WEBSOCKET !== '1' &&
     typeof WebSocket !== 'undefined'
   ) {
     const ws = new WebSocket(

--- a/packages/edge-config/src/utils/swr-fn.test.ts
+++ b/packages/edge-config/src/utils/swr-fn.test.ts
@@ -5,13 +5,13 @@ const delay = (ms = 500): Promise<void> =>
     setTimeout(resolve, ms);
   });
 
-function lift(): [(value: string) => void, Promise<string>] {
+function lift(): [(value: string) => void, Promise<unknown>] {
   let resolve: ((value: string) => void) | undefined;
-  const promise = new Promise((r) => {
+  const promise = new Promise<unknown>((r) => {
     resolve = r;
   });
 
-  // @ts-expect-error -- resolve is actually defined
+  if (!resolve) throw new Error('resolve not defined');
   return [resolve, promise];
 }
 

--- a/packages/edge-config/src/utils/swr-fn.test.ts
+++ b/packages/edge-config/src/utils/swr-fn.test.ts
@@ -90,4 +90,22 @@ describe('swr-fn', () => {
     await expect(swrFn()).resolves.toEqual('later');
     fn.mockResolvedValueOnce('end');
   });
+
+  it('is not possible to mutate values', async () => {
+    const fn = jest.fn((): Promise<string[]> => Promise.resolve([]));
+    const swrFn = swr(fn);
+
+    const list = ['a'];
+
+    // initial call to fill stale value
+    fn.mockResolvedValueOnce(list);
+    const result = await swrFn();
+    expect(result).toEqual(['a']);
+
+    // mutate
+    result.push('b');
+
+    await expect(swrFn()).resolves.toEqual(['a']);
+    fn.mockResolvedValueOnce([]);
+  });
 });

--- a/packages/edge-config/src/utils/swr-fn.test.ts
+++ b/packages/edge-config/src/utils/swr-fn.test.ts
@@ -1,0 +1,59 @@
+import { swr } from './swr-fn';
+
+const delay = (ms = 500): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+describe('swr-fn', () => {
+  it('reuses stale values', async () => {
+    const fn = jest.fn();
+    const swrFn = swr(fn);
+    fn.mockResolvedValueOnce('a');
+    await expect(swrFn()).resolves.toEqual('a');
+
+    // here we ensure the next value resolves with "b", but
+    // we expect the current call to respond with the stale value "a"
+    fn.mockResolvedValueOnce('b');
+    await expect(swrFn()).resolves.toEqual('a');
+    fn.mockResolvedValueOnce('end');
+  });
+
+  it('returns before values resolve in the background', async () => {
+    const fn = jest.fn();
+    const swrFn = swr(fn);
+
+    fn.mockResolvedValueOnce('a');
+    await expect(swrFn()).resolves.toEqual('a');
+
+    // here we only resolve the value to "b" after the second invocation,
+    // and ensure the second invocation responds with the stale "a" value
+    let resolve: null | ((value: string) => void) = null;
+    const p = new Promise((r) => {
+      resolve = r;
+    });
+    fn.mockReturnValue(p);
+    await expect(swrFn()).resolves.toEqual('a');
+    // @ts-expect-error -- will be defined
+    resolve('b');
+
+    // we need to give the promise a chance to update the value before
+    // the next assertion
+    await delay(0);
+    await expect(swrFn()).resolves.toEqual('b');
+    fn.mockResolvedValueOnce('end');
+  });
+
+  it('does not store rejected promises', async () => {
+    const fn = jest.fn();
+    const swrFn = swr(fn);
+
+    fn.mockResolvedValueOnce('a');
+    await expect(swrFn()).resolves.toEqual('a');
+
+    // here we fall back to the last working value
+    fn.mockRejectedValueOnce('error');
+    await expect(swrFn()).resolves.toEqual('a');
+    fn.mockResolvedValueOnce('end');
+  });
+});

--- a/packages/edge-config/src/utils/swr-fn.ts
+++ b/packages/edge-config/src/utils/swr-fn.ts
@@ -1,0 +1,35 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument -- any necessary for generics */
+function clone<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v)) as T;
+}
+
+/**
+ * Adds swr behavior to any async function.
+ */
+export function swr<T extends (...args: any[]) => Promise<any>>(fn: T): T {
+  let latestInvocationId = 0;
+  let staleValuePromise: null | Promise<unknown> = null;
+
+  return (async (...args: any[]) => {
+    const currentInvocationId = ++latestInvocationId;
+
+    if (staleValuePromise) {
+      // clone to avoid referential equality of the returned value,
+      // which would unlock mutations
+      void fn(...args).then((result) => {
+        if (currentInvocationId === latestInvocationId) {
+          staleValuePromise = Promise.resolve(result);
+        }
+      });
+      return staleValuePromise.then(clone);
+    }
+
+    const resultPromise = fn(...args);
+    staleValuePromise = resultPromise.catch((e) => {
+      staleValuePromise = null;
+      throw e;
+    });
+    return resultPromise;
+  }) as T;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument -- reenabling the rule */

--- a/packages/edge-config/src/utils/swr-fn.ts
+++ b/packages/edge-config/src/utils/swr-fn.ts
@@ -28,11 +28,11 @@ export function swr<T extends (...args: any[]) => Promise<any>>(fn: T): T {
     }
 
     const resultPromise = fn(...args);
-    staleValuePromise = resultPromise.catch((e) => {
+    staleValuePromise = resultPromise.then(clone, (e) => {
       staleValuePromise = null;
       throw e;
     });
-    return resultPromise;
+    return resultPromise.then(clone);
   }) as T;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument -- reenabling the rule */

--- a/packages/edge-config/src/utils/swr-fn.ts
+++ b/packages/edge-config/src/utils/swr-fn.ts
@@ -16,11 +16,14 @@ export function swr<T extends (...args: any[]) => Promise<any>>(fn: T): T {
     if (staleValuePromise) {
       // clone to avoid referential equality of the returned value,
       // which would unlock mutations
-      void fn(...args).then((result) => {
-        if (currentInvocationId === latestInvocationId) {
-          staleValuePromise = Promise.resolve(result);
-        }
-      });
+      void fn(...args).then(
+        (result) => {
+          if (currentInvocationId === latestInvocationId) {
+            staleValuePromise = Promise.resolve(result);
+          }
+        },
+        () => void 0,
+      );
       return staleValuePromise.then(clone);
     }
 

--- a/test/next/src/app/api/vercel/edge-config/route.ts
+++ b/test/next/src/app/api/vercel/edge-config/route.ts
@@ -4,10 +4,8 @@ import { NextResponse } from 'next/server';
 export const runtime = 'edge';
 
 export async function GET(): Promise<Response> {
-  // eslint-disable-next-line no-console
-  console.time('read duration');
+  const before = Date.now();
   const keyForTest = await get<string>('keyForTest');
-  // eslint-disable-next-line no-console
-  console.timeEnd('read duration');
-  return NextResponse.json({ keyForTest });
+  const after = Date.now();
+  return NextResponse.json({ keyForTest, durationMs: after - before });
 }

--- a/test/next/src/app/api/vercel/edge-config/route.ts
+++ b/test/next/src/app/api/vercel/edge-config/route.ts
@@ -1,0 +1,13 @@
+import { get } from '@vercel/edge-config';
+import { NextResponse } from 'next/server';
+
+export const runtime = 'edge';
+
+export async function GET(): Promise<Response> {
+  // eslint-disable-next-line no-console
+  console.time('read duration');
+  const keyForTest = await get<string>('keyForTest');
+  // eslint-disable-next-line no-console
+  console.timeEnd('read duration');
+  return NextResponse.json({ keyForTest });
+}


### PR DESCRIPTION
This is a tiny optimization relevant for development only.

At the moment reading edge config in preview and production is orders of magnitude faster than reading edge config in development, since we can't apply the same optimizations when reading edge config in development.

While in development we were sending a network request on every read. This only takes ~20-100ms to resolve, but we can actually do better. Instead of sending and awaiting a HTTP request for every read, we now use swr semantics to return a value early while refreshing it in the background.

This optimization brings subsequent reads during development down to under 5ms, while still ensuring updates are propagated after the next refresh. 

The downside of this approach is that it introduces a slight divide between the logic running in development and production.

Disabling this behavior is possible by setting the `EDGE_CONFIG_DISABLE_DEVELOPMENT_SWR` env var. This swr behavior is also disabled by default if `NODE_ENV` is anything other than `development` to prevent this from running on preview or production deployments.