### PR TITLE
feat(blob): add  list `mode` param to merge blob folder

### DIFF
--- a/.changeset/metal-pigs-hear.md
+++ b/.changeset/metal-pigs-hear.md
@@ -1,0 +1,5 @@
+---
+"@vercel/blob": minor
+---
+
+Adds a new `mode` parameter to the list command options. Mode controls the way our API handles folders and blob files.

--- a/.changeset/metal-pigs-hear.md
+++ b/.changeset/metal-pigs-hear.md
@@ -2,4 +2,4 @@
 "@vercel/blob": minor
 ---
 
-Adds a new `mode` parameter to the list command options. Mode controls the way our API handles folders and blob files.
+Adds a new `mode: folded | expanded (default)` parameter to the list command options. When you pass `folded` to `mode`, then we automatically fold all files belonging to the same folder into a single folder entry. This allows you to build file browsers using the Vercel Blob API.

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -45,7 +45,7 @@
     "prepublishOnly": "pnpm run build",
     "prettier-check": "prettier --check .",
     "publint": "npx publint",
-    "test": "pnpm run test:node && pnpm run test:edge && pnpm run test:browser",
+    "test": "pnpm run test:node && pnpm run test:edge && pnpm run  test:browser",
     "test:browser": "jest --env jsdom .browser.test.ts --setupFilesAfterEnv ./jest/setup.js",
     "test:edge": "jest --env @edge-runtime/jest-environment .edge.test.ts",
     "test:node": "jest --env node .node.test.ts",

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -45,7 +45,7 @@
     "prepublishOnly": "pnpm run build",
     "prettier-check": "prettier --check .",
     "publint": "npx publint",
-    "test": "pnpm run test:node && pnpm run test:edge && pnpm run  test:browser",
+    "test": "pnpm run test:node && pnpm run test:edge && pnpm run test:browser",
     "test:browser": "jest --env jsdom .browser.test.ts --setupFilesAfterEnv ./jest/setup.js",
     "test:edge": "jest --env @edge-runtime/jest-environment .edge.test.ts",
     "test:node": "jest --env node .node.test.ts",

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -314,6 +314,45 @@ describe('blob client', () => {
         ),
       );
     });
+
+    it('list should pass the mode param and return folders array', async () => {
+      let path: string | null = null;
+
+      mockClient
+        .intercept({
+          path: () => true,
+          method: 'GET',
+        })
+        .reply(200, (req) => {
+          path = req.path;
+          return {
+            blobs: [mockedFileMetaList],
+            folders: ['foo', 'bar'],
+            hasMore: false,
+          };
+        });
+
+      await expect(list({ mode: 'folded' })).resolves.toMatchInlineSnapshot(`
+        {
+          "blobs": [
+            {
+              "pathname": "foo.txt",
+              "size": 12345,
+              "uploadedAt": 2023-05-04T15:12:07.818Z,
+              "url": "https://storeId.public.blob.vercel-storage.com/foo-id.txt",
+            },
+          ],
+          "cursor": undefined,
+          "folders": [
+            "foo",
+            "bar",
+          ],
+          "hasMore": false,
+        }
+      `);
+
+      expect(path).toBe('/?mode=folded');
+    });
   });
 
   describe('put', () => {

--- a/packages/blob/src/index.ts
+++ b/packages/blob/src/index.ts
@@ -44,6 +44,7 @@ export type {
   ListBlobResultBlob,
   ListBlobResult,
   ListCommandOptions,
+  ListFoldedBlobResult as FoldedListBlobResult,
 } from './list';
 export { list } from './list';
 

--- a/packages/blob/src/index.ts
+++ b/packages/blob/src/index.ts
@@ -44,7 +44,7 @@ export type {
   ListBlobResultBlob,
   ListBlobResult,
   ListCommandOptions,
-  ListFoldedBlobResult as FoldedListBlobResult,
+  ListFoldedBlobResult,
 } from './list';
 export { list } from './list';
 

--- a/packages/blob/src/list.ts
+++ b/packages/blob/src/list.ts
@@ -60,23 +60,19 @@ export interface ListCommandOptions<
   mode?: M;
 }
 
+type ListCommandResult<
+  M extends 'expanded' | 'folded' | undefined = undefined,
+> = M extends 'folded' ? ListFoldedBlobResult : ListBlobResult;
+
 /**
  * Fetches a paginated list of blob objects from your store.
  * Detailed documentation can be found here: https://vercel.com/docs/storage/vercel-blob/using-blob-sdk#list-blobs
  *
  * @param options - Additional options for the request.
  */
-export async function list(): Promise<ListBlobResult>;
-
 export async function list<
   M extends 'expanded' | 'folded' | undefined = undefined,
->(
-  options: ListCommandOptions<M>,
-): Promise<M extends 'folded' ? ListFoldedBlobResult : ListBlobResult>;
-
-export async function list(
-  options?: ListCommandOptions<'expanded' | 'folded'>,
-): Promise<ListFoldedBlobResult | ListBlobResult> {
+>(options?: ListCommandOptions<M>): Promise<ListCommandResult<M>> {
   const listApiUrl = new URL(getApiUrl());
   if (options?.limit) {
     listApiUrl.searchParams.set('limit', options.limit.toString());
@@ -109,14 +105,14 @@ export async function list(
       cursor: results.cursor,
       hasMore: results.hasMore,
       blobs: results.blobs.map(mapBlobResult),
-    };
+    } as ListCommandResult<M>;
   }
 
   return {
     cursor: results.cursor,
     hasMore: results.hasMore,
     blobs: results.blobs.map(mapBlobResult),
-  };
+  } as ListCommandResult<M>;
 }
 
 function mapBlobResult(

--- a/test/next/src/app/vercel/blob/script.mts
+++ b/test/next/src/app/vercel/blob/script.mts
@@ -284,23 +284,7 @@ async function listFolders() {
   });
 
   const response = await vercelBlob.list({
-    cursor: '123',
-  });
-
-  const response2 = await vercelBlob.list();
-
-  const response3 = await vercelBlob.list({});
-
-  const response4 = await vercelBlob.list({
     mode: 'folded',
-  });
-
-  const respons52 = await vercelBlob.list({
-    mode: 'expanded',
-  });
-
-  const response6 = await vercelBlob.list({
-    mode: '',
   });
 
   console.log('fold blobs example:', response, `(${Date.now() - start}ms)`);

--- a/test/next/src/app/vercel/blob/script.mts
+++ b/test/next/src/app/vercel/blob/script.mts
@@ -18,19 +18,20 @@ console.log();
 
 async function run(): Promise<void> {
   const urls = await Promise.all([
-    textFileExample(),
-    textFileNoRandomSuffixExample(),
-    textFileExampleWithCacheControlMaxAge(),
-    imageExample(),
-    videoExample(),
-    webpageExample(),
-    incomingMessageExample(),
-    axiosExample(),
-    gotExample(),
-    fetchExample(),
-    noExtensionExample(),
-    weirdCharactersExample(),
-    copyTextFile(),
+    // textFileExample(),
+    // textFileNoRandomSuffixExample(),
+    // textFileExampleWithCacheControlMaxAge(),
+    // imageExample(),
+    // videoExample(),
+    // webpageExample(),
+    // incomingMessageExample(),
+    // axiosExample(),
+    // gotExample(),
+    // fetchExample(),
+    // noExtensionExample(),
+    // weirdCharactersExample(),
+    // copyTextFile(),
+    listFolders(),
   ]);
 
   await Promise.all(
@@ -273,4 +274,20 @@ async function copyTextFile() {
   await vercelBlob.del(blob.url);
 
   return copiedBlob.url;
+}
+
+async function listFolders() {
+  const start = Date.now();
+
+  const blob = await vercelBlob.put('foo/bar.txt', 'Hello, world!', {
+    access: 'public',
+  });
+
+  const response = await vercelBlob.list({
+    mode: 'folded',
+  });
+
+  console.log('fold blobs example:', response, `(${Date.now() - start}ms)`);
+
+  return blob.url;
 }

--- a/test/next/src/app/vercel/blob/script.mts
+++ b/test/next/src/app/vercel/blob/script.mts
@@ -284,7 +284,23 @@ async function listFolders() {
   });
 
   const response = await vercelBlob.list({
+    cursor: '123',
+  });
+
+  const response2 = await vercelBlob.list();
+
+  const response3 = await vercelBlob.list({});
+
+  const response4 = await vercelBlob.list({
     mode: 'folded',
+  });
+
+  const respons52 = await vercelBlob.list({
+    mode: 'expanded',
+  });
+
+  const response6 = await vercelBlob.list({
+    mode: '',
   });
 
   console.log('fold blobs example:', response, `(${Date.now() - start}ms)`);

--- a/test/next/src/app/vercel/blob/script.mts
+++ b/test/next/src/app/vercel/blob/script.mts
@@ -18,19 +18,19 @@ console.log();
 
 async function run(): Promise<void> {
   const urls = await Promise.all([
-    // textFileExample(),
-    // textFileNoRandomSuffixExample(),
-    // textFileExampleWithCacheControlMaxAge(),
-    // imageExample(),
-    // videoExample(),
-    // webpageExample(),
-    // incomingMessageExample(),
-    // axiosExample(),
-    // gotExample(),
-    // fetchExample(),
-    // noExtensionExample(),
-    // weirdCharactersExample(),
-    // copyTextFile(),
+    textFileExample(),
+    textFileNoRandomSuffixExample(),
+    textFileExampleWithCacheControlMaxAge(),
+    imageExample(),
+    videoExample(),
+    webpageExample(),
+    incomingMessageExample(),
+    axiosExample(),
+    gotExample(),
+    fetchExample(),
+    noExtensionExample(),
+    weirdCharactersExample(),
+    copyTextFile(),
     listFolders(),
   ]);
 


### PR DESCRIPTION
This PR introduces a new `mode` param to the `list` options object. Based on this param the response either contains only blobs or in addition to that also list of folders.