### PR TITLE
feat: Better templating for `@vercel/postgres`

### DIFF
--- a/.changeset/heavy-ducks-tickle.md
+++ b/.changeset/heavy-ducks-tickle.md
@@ -1,0 +1,5 @@
+---
+'@vercel/postgres': minor
+---
+
+feat: Improved tagged template syntax

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -53,7 +53,7 @@
     "@changesets/cli": "2.26.2",
     "@edge-runtime/jest-environment": "2.3.6",
     "@edge-runtime/types": "2.2.6",
-    "@sejohnson/tql": "0.0.2-beta.1",
+    "@sejohnson/tql": "^1.0.0",
     "@types/jest": "29.5.7",
     "@types/node": "20.8.10",
     "@types/ws": "8.5.8",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -53,6 +53,7 @@
     "@changesets/cli": "2.26.2",
     "@edge-runtime/jest-environment": "2.3.6",
     "@edge-runtime/types": "2.2.6",
+    "@sejohnson/tql": "0.0.2-beta.1",
     "@types/jest": "29.5.7",
     "@types/node": "20.8.10",
     "@types/ws": "8.5.8",

--- a/packages/postgres/src/create-client.ts
+++ b/packages/postgres/src/create-client.ts
@@ -7,8 +7,7 @@ import {
   postgresConnectionString,
 } from './postgres-connection-string';
 import { VercelPostgresError } from './error';
-import type { Primitive } from './sql-template';
-import { sqlTemplate } from './sql-template';
+import { tql } from './sql-template';
 
 export class VercelClient extends Client {
   /**
@@ -28,9 +27,9 @@ export class VercelClient extends Client {
    */
   async sql<O extends QueryResultRow>(
     strings: TemplateStringsArray,
-    ...values: Primitive[]
+    ...values: unknown[]
   ): Promise<QueryResult<O>> {
-    const [query, params] = sqlTemplate(strings, ...values);
+    const [query, params] = tql.query(strings, ...values);
     return this.query(query, params);
   }
 }

--- a/packages/postgres/src/create-pool.ts
+++ b/packages/postgres/src/create-pool.ts
@@ -11,8 +11,7 @@ import {
   postgresConnectionString,
 } from './postgres-connection-string';
 import { VercelPostgresError } from './error';
-import type { Primitive } from './sql-template';
-import { sqlTemplate } from './sql-template';
+import { tql } from './sql-template';
 import { VercelClient } from './create-client';
 
 export class VercelPool extends Pool {
@@ -39,9 +38,9 @@ export class VercelPool extends Pool {
    */
   async sql<O extends QueryResultRow>(
     strings: TemplateStringsArray,
-    ...values: Primitive[]
+    ...values: unknown[]
   ): Promise<QueryResult<O>> {
-    const [query, params] = sqlTemplate(strings, ...values);
+    const [query, params] = tql.query(strings, ...values);
 
     const sql = neon(this.connectionString, {
       fullResults: true,

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -1,11 +1,22 @@
 import type { QueryResult, QueryResultRow } from '@neondatabase/serverless';
 import { type VercelPool, createPool } from './create-pool';
-import type { Primitive } from './sql-template';
+import { tql } from './sql-template';
 
 export * from './create-client';
 export * from './create-pool';
 export * from './types';
 export { postgresConnectionString } from './postgres-connection-string';
+
+export const {
+  fragment,
+  identifier,
+  identifiers,
+  list,
+  values,
+  set,
+  unsafe,
+  query: debug,
+} = tql;
 
 let pool: VercelPool | undefined;
 
@@ -46,7 +57,7 @@ export const sql = new Proxy(
 ) as unknown as VercelPool &
   (<O extends QueryResultRow>(
     strings: TemplateStringsArray,
-    ...values: Primitive[]
+    ...values: unknown[]
   ) => Promise<QueryResult<O>>);
 
 export const db = sql;

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -9,7 +9,6 @@ export { postgresConnectionString } from './postgres-connection-string';
 
 export const {
   fragment,
-  identifier,
   identifiers,
   list,
   values,

--- a/packages/postgres/src/sql-template.test.ts
+++ b/packages/postgres/src/sql-template.test.ts
@@ -1,24 +1,24 @@
 import { VercelPostgresError } from './error';
-import { sqlTemplate } from './sql-template';
+import { tql } from './sql-template';
 
 const validCases = [
   {
-    input: sqlTemplate`SELECT * FROM users WHERE id = ${123}`,
+    input: tql.query`SELECT * FROM users WHERE id = ${123}`,
     output: ['SELECT * FROM users WHERE id = $1', [123]],
   },
   {
-    input: sqlTemplate`SELECT * FROM users WHERE id = ${123} AND name = ${'John'}`,
+    input: tql.query`SELECT * FROM users WHERE id = ${123} AND name = ${'John'}`,
     output: ['SELECT * FROM users WHERE id = $1 AND name = $2', [123, 'John']],
   },
   {
-    input: sqlTemplate`SELECT * FROM users WHERE name = ${'John; DROP TABLE users;--'}`,
+    input: tql.query`SELECT * FROM users WHERE name = ${'John; DROP TABLE users;--'}`,
     output: [
       'SELECT * FROM users WHERE name = $1',
       ['John; DROP TABLE users;--'],
     ],
   },
   {
-    input: sqlTemplate`SELECT * FROM users WHERE name = ${'John AND 1=1'}`,
+    input: tql.query`SELECT * FROM users WHERE name = ${'John AND 1=1'}`,
     output: ['SELECT * FROM users WHERE name = $1', ['John AND 1=1']],
   },
 ];

--- a/packages/postgres/src/sql-template.test.ts
+++ b/packages/postgres/src/sql-template.test.ts
@@ -34,18 +34,18 @@ describe('sql', () => {
     const likes = 100;
     expect(() => {
       // @ts-expect-error - intentionally incorrect usage
-      sqlTemplate(`SELECT * FROM posts WHERE likes > ${likes}`);
+      tql.query(`SELECT * FROM posts WHERE likes > ${likes}`);
     }).toThrow(VercelPostgresError);
   });
   it('throws when deliberately not used as a tagged literal to try to make us look dumb', () => {
     const likes = 100;
     expect(() => {
       // @ts-expect-error - intentionally incorrect usage
-      sqlTemplate([`SELECT * FROM posts WHERE likes > ${likes}`]);
+      tql.query([`SELECT * FROM posts WHERE likes > ${likes}`]);
     }).toThrow(VercelPostgresError);
     expect(() => {
       // @ts-expect-error - intentionally incorrect usage
-      sqlTemplate(`SELECT * FROM posts WHERE likes > ${likes}`, 123);
+      tql.query(`SELECT * FROM posts WHERE likes > ${likes}`, 123);
     }).toThrow(VercelPostgresError);
   });
 });

--- a/packages/postgres/src/sql-template.ts
+++ b/packages/postgres/src/sql-template.ts
@@ -1,3 +1,31 @@
-import { init, PostgresDialect } from '@sejohnson/tql';
+import { type CompiledQuery, init, PostgresDialect } from '@sejohnson/tql';
+import { VercelPostgresError } from './error';
 
-export const tql = init({ dialect: PostgresDialect });
+const { query, ...rest } = init({ dialect: PostgresDialect });
+
+export const tql = {
+  query: (
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): CompiledQuery => {
+    try {
+      return query(strings, ...values);
+    } catch (e) {
+      // this is for backwards-compatibility; there's no reason we can't remove it in a future major
+      if (
+        typeof e === 'object' &&
+        e !== null &&
+        'code' in e &&
+        typeof e.code === 'string' &&
+        e.code === 'untemplated_sql_call'
+      ) {
+        throw new VercelPostgresError(
+          'incorrect_tagged_template_call',
+          "It looks like you tried to call `sql` as a function. Make sure to use it as a tagged template.\n\tExample: sql`SELECT * FROM users`, not sql('SELECT * FROM users')",
+        );
+      }
+      throw e;
+    }
+  },
+  ...rest,
+};

--- a/packages/postgres/src/sql-template.ts
+++ b/packages/postgres/src/sql-template.ts
@@ -1,31 +1,3 @@
-import { VercelPostgresError } from './error';
+import { init, PostgresDialect } from '@sejohnson/tql';
 
-export type Primitive = string | number | boolean | undefined | null;
-
-export function sqlTemplate(
-  strings: TemplateStringsArray,
-  ...values: Primitive[]
-): [string, Primitive[]] {
-  if (!isTemplateStringsArray(strings) || !Array.isArray(values)) {
-    throw new VercelPostgresError(
-      'incorrect_tagged_template_call',
-      "It looks like you tried to call `sql` as a function. Make sure to use it as a tagged template.\n\tExample: sql`SELECT * FROM users`, not sql('SELECT * FROM users')",
-    );
-  }
-
-  let result = strings[0] ?? '';
-
-  for (let i = 1; i < strings.length; i++) {
-    result += `$${i}${strings[i] ?? ''}`;
-  }
-
-  return [result, values];
-}
-
-function isTemplateStringsArray(
-  strings: unknown,
-): strings is TemplateStringsArray {
-  return (
-    Array.isArray(strings) && 'raw' in strings && Array.isArray(strings.raw)
-  );
-}
+export const tql = init({ dialect: PostgresDialect });

--- a/packages/postgres/src/types.ts
+++ b/packages/postgres/src/types.ts
@@ -5,7 +5,6 @@ import type {
   QueryResult,
   QueryResultRow,
 } from '@neondatabase/serverless';
-import { type Primitive } from './sql-template';
 
 export type {
   Pool,
@@ -28,7 +27,7 @@ export type VercelPostgresPoolConfig = Omit<PoolConfig, ConfigItemsToOmit>;
 export interface VercelClientBase extends ClientBase {
   sql: <O extends QueryResultRow>(
     strings: TemplateStringsArray,
-    ...values: Primitive[]
+    ...values: unknown[]
   ) => Promise<QueryResult<O>>;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,7 +216,7 @@ importers:
         specifier: 2.2.6
         version: 2.2.6
       '@sejohnson/tql':
-        specifier: 1.0.2
+        specifier: ^1.0.0
         version: 1.0.2
       '@types/jest':
         specifier: 29.5.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       '@edge-runtime/types':
         specifier: 2.2.6
         version: 2.2.6
+      '@sejohnson/tql':
+        specifier: 0.0.2-beta.1
+        version: 0.0.2-beta.1
       '@types/jest':
         specifier: 29.5.7
         version: 29.5.7
@@ -1693,6 +1696,11 @@ packages:
 
   /@rushstack/eslint-patch@1.5.1:
     resolution: {integrity: sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==}
+
+  /@sejohnson/tql@0.0.2-beta.1:
+    resolution: {integrity: sha512-+K5pwWLeBCCzBKkBzN7pVtwtm/YpgzNEJHToScXxqHXMikUgpUTHSl3vLKMUbzDYHXLnCwzkVIFylYwTytV6Lg==}
+    engines: {node: '>=18.0.0'}
+    dev: true
 
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,8 +216,8 @@ importers:
         specifier: 2.2.6
         version: 2.2.6
       '@sejohnson/tql':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: 1.0.2
+        version: 1.0.2
       '@types/jest':
         specifier: 29.5.7
         version: 29.5.7
@@ -1697,8 +1697,8 @@ packages:
   /@rushstack/eslint-patch@1.5.1:
     resolution: {integrity: sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==}
 
-  /@sejohnson/tql@1.0.0:
-    resolution: {integrity: sha512-Rja2JWNlJJicDPYrI5um7Mj9gKj3lk+HFtbSVmiRkuEOWegaDXLJWxb2RXbzyqOcRDonZW3Q6ajznDhz/8Sf1w==}
+  /@sejohnson/tql@1.0.2:
+    resolution: {integrity: sha512-VOtRIaCvRBNQ7jhF6I2au6O0o2+sDjysI+vDDy3eKmBN5LPorIuqKYXU8Dam+SmVKkZ2OxgfIegP0u7mXUpT3Q==}
     engines: {node: '>=18.0.0'}
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,8 +216,8 @@ importers:
         specifier: 2.2.6
         version: 2.2.6
       '@sejohnson/tql':
-        specifier: 0.0.2-beta.1
-        version: 0.0.2-beta.1
+        specifier: ^1.0.0
+        version: 1.0.0
       '@types/jest':
         specifier: 29.5.7
         version: 29.5.7
@@ -1697,8 +1697,8 @@ packages:
   /@rushstack/eslint-patch@1.5.1:
     resolution: {integrity: sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==}
 
-  /@sejohnson/tql@0.0.2-beta.1:
-    resolution: {integrity: sha512-+K5pwWLeBCCzBKkBzN7pVtwtm/YpgzNEJHToScXxqHXMikUgpUTHSl3vLKMUbzDYHXLnCwzkVIFylYwTytV6Lg==}
+  /@sejohnson/tql@1.0.0:
+    resolution: {integrity: sha512-Rja2JWNlJJicDPYrI5um7Mj9gKj3lk+HFtbSVmiRkuEOWegaDXLJWxb2RXbzyqOcRDonZW3Q6ajznDhz/8Sf1w==}
     engines: {node: '>=18.0.0'}
     dev: true
 


### PR DESCRIPTION
# TODO:

- [ ] Security audit
- [ ] API approval
- [ ] README

# What problem does this fix?

Right now, SQL templating is very limited. This is cool:

```ts
// this works great!
const { rows } = await sql`SELECT * FROM users WHERE user_id = ${userId}`;
```

... but it falls apart quickly:

```ts
// nope!
const { rows } = await sql`SELECT * FROM users WHERE user_id IN (${userIds})`;
```

It completely falls apart for any sort of dynamic query building, such as is often required for bulk `UPDATE` / `INSERT` statements. This adds the following API surface area:

| Utility       | Signature                                                                                                                            | Purpose                                                                                                                                                                                                                                                       |
| ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `debug`       | `(strings: TemplateStringsArray, ...values: unknown[]) => [string, unknown[]]`                                                       | Returns a tuple of your query and its parameters -- useful if you need to log the final compiled query to see what's going wrong.                                                                                                                  |
| `fragment`    | `(strings: TemplateStringsArray, ...values: unknown[]) => [string, unknown[]]`                                                       | Has the same API as `query`, but returns a `TqlFragment` node which can be recursively nested within itself and included in a top-level `query`.                                                                                                              |
| `identifiers` | <code>(ids: string &#124; string[]) => TqlIdentifiers</code>                                                                         | Accepts a list of strings, escapes them, and inserts them into the query as identifiers (table or column names). Identifiers are safe and easy to escape, unlike query values! Will also accept a single identifier, for convenience.                         |
| `list`        | `(parameters: unknown[]) => TqlList`                                                                                                 | Accepts a list of anything and inserts it into the query as a parameterized list. For example, `[1, 2, 3]` would become `($1, $2, $3)` with the original values stored in the parameters array.                                                               |
| `values`      | `(entries: ValuesObject) => TqlValues`, where `ValuesObject` is `{ [columnName: string]: unknown }` or an array of that object type. | Accepts an array of records (or, for convenience, a single record) and builds a VALUES clause out of it. See the example below for a full explanation.                                                                                                        |
| `set`         | `(entry: SetObject) => TqlSet`, where `SetObject` is `{ [columnName: string]: unknown }`.                                            | Accepts a record representing the SET clause, and returns a parameterized SET clause. See example below for a full explanation.                                                                                                                               |
| `unsafe`      | `(str: string) => TqlTemplateString`                                                                                                 | Accepts a string and returns a representation of the string that will be inserted VERBATIM, UNESCAPED into the compiled query. Please, for all that is good, it's in the name -- this is unsafe. Do not use it unless you absolutely know your input is safe. |

The API for `sql` remains unchanged.

## An example, using the above (obviously somewhat contrived to show how various API works):

```ts
import { sql, fragment, identifiers, values } from '@vercel/postgres';

const newUser = { first_name: 'vercelliott', family_name: 'smith' };

// these could come from a column picker
const columns = identifiers(['first_name', 'family_name']);

const insertStatement = fragment`
  INSERT INTO users ${values(newUser)}
  RETURNING family_name
`;

const { rows: familyMembers } = await sql`
WITH new_user AS (
  ${insertStatement}
)

SELECT ${columns} 
FROM users
WHERE family_name IN (SELECT family_name FROM new_user);
`
```

[Full docs for the TQL spec](https://www.npmjs.com/package/@sejohnson/tql?activeTab=readme)

