### PR TITLE
feat(blob): throw specific error when service unavailable

### DIFF
--- a/.changeset/wicked-gifts-tell.md
+++ b/.changeset/wicked-gifts-tell.md
@@ -1,0 +1,5 @@
+---
+"@vercel/blob": minor
+---
+
+feat(blob): throw specific error when service unavailable

--- a/packages/blob/src/helpers.ts
+++ b/packages/blob/src/helpers.ts
@@ -84,6 +84,12 @@ export class BlobNotFoundError extends BlobError {
   }
 }
 
+export class BlobServiceNotAvailable extends BlobError {
+  constructor() {
+    super('The blob service is currently not available. Please try again');
+  }
+}
+
 type BlobApiErrorCodes =
   | 'store_suspended'
   | 'forbidden'
@@ -91,7 +97,8 @@ type BlobApiErrorCodes =
   | 'unknown_error'
   | 'bad_request'
   | 'store_not_found'
-  | 'not_allowed';
+  | 'not_allowed'
+  | 'service_unavailable';
 
 interface BlobApiError {
   error?: { code?: BlobApiErrorCodes; message?: string };
@@ -101,33 +108,33 @@ export async function validateBlobApiResponse(
   response: Response,
 ): Promise<void> {
   if (!response.ok) {
-    if (response.status >= 500) {
-      throw new BlobUnknownError();
-    } else {
-      let data: unknown;
-      try {
-        data = await response.json();
-      } catch {
-        throw new BlobUnknownError();
-      }
-      const error = (data as BlobApiError).error;
+    let data: unknown;
 
-      switch (error?.code) {
-        case 'store_suspended':
-          throw new BlobStoreSuspendedError();
-        case 'forbidden':
-          throw new BlobAccessError();
-        case 'not_found':
-          throw new BlobNotFoundError();
-        case 'store_not_found':
-          throw new BlobStoreNotFoundError();
-        case 'bad_request':
-          throw new BlobError(error.message ?? 'Bad request');
-        case 'unknown_error':
-        case 'not_allowed':
-        default:
-          throw new BlobUnknownError();
-      }
+    try {
+      data = await response.json();
+    } catch {
+      throw new BlobUnknownError();
+    }
+
+    const error = (data as BlobApiError).error;
+
+    switch (error?.code) {
+      case 'store_suspended':
+        throw new BlobStoreSuspendedError();
+      case 'forbidden':
+        throw new BlobAccessError();
+      case 'not_found':
+        throw new BlobNotFoundError();
+      case 'store_not_found':
+        throw new BlobStoreNotFoundError();
+      case 'bad_request':
+        throw new BlobError(error.message ?? 'Bad request');
+      case 'service_unavailable':
+        throw new BlobServiceNotAvailable();
+      case 'unknown_error':
+      case 'not_allowed':
+      default:
+        throw new BlobUnknownError();
     }
   }
 }

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -1,5 +1,6 @@
 import { type Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
 import { list, head, del, put } from './index';
+import { BlobServiceNotAvailable } from './helpers';
 
 const BLOB_API_URL = 'https://blob.vercel-storage.com';
 const BLOB_STORE_BASE_URL = 'https://storeId.public.blob.vercel-storage.com';
@@ -136,6 +137,19 @@ describe('blob client', () => {
 
       await expect(head(`${BLOB_STORE_BASE_URL}/foo-id.txt`)).rejects.toThrow(
         new Error('Vercel Blob: This store does not exist'),
+      );
+    });
+
+    it('should throw when service unavailable', async () => {
+      mockClient
+        .intercept({
+          path: () => true,
+          method: 'GET',
+        })
+        .reply(502, { error: { code: 'service_unavailable' } });
+
+      await expect(head(`${BLOB_STORE_BASE_URL}/foo-id.txt`)).rejects.toThrow(
+        new BlobServiceNotAvailable(),
       );
     });
   });

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -1,6 +1,6 @@
 import { type Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
-import { list, head, del, put } from './index';
 import { BlobServiceNotAvailable } from './helpers';
+import { list, head, del, put } from './index';
 
 const BLOB_API_URL = 'https://blob.vercel-storage.com';
 const BLOB_STORE_BASE_URL = 'https://storeId.public.blob.vercel-storage.com';

--- a/packages/blob/src/index.ts
+++ b/packages/blob/src/index.ts
@@ -9,6 +9,7 @@ export {
   BlobStoreNotFoundError,
   BlobStoreSuspendedError,
   BlobUnknownError,
+  BlobServiceNotAvailable,
 } from './helpers';
 
 // vercelBlob.put()


### PR DESCRIPTION
We return 503 `service_unavailable` from our API when our upstream provider can't handle the request and responds with `ServiceUnavailable` or `InternalError`. If this error occurs the client could retry the operation.