### PR TITLE
remove unnecessary build steps

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,7 @@
       "dependsOn": ["^build"]
     },
     "publint": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "build"]
     },
     "prettier-check": {},
     "integration-test": {

--- a/turbo.json
+++ b/turbo.json
@@ -6,16 +6,16 @@
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "lint": {
-      "dependsOn": ["^build", "build"]
+      "dependsOn": ["^build"]
     },
     "type-check": {
-      "dependsOn": ["^build", "build"]
+      "dependsOn": ["^build"]
     },
     "test": {
-      "dependsOn": ["^build", "build"]
+      "dependsOn": ["^build"]
     },
     "publint": {
-      "dependsOn": ["^build", "build"]
+      "dependsOn": ["^build"]
     },
     "prettier-check": {},
     "integration-test": {


### PR DESCRIPTION
Removes unnecessary build steps from the config to speed up the results of `lint`, `test` & co.