### PR TITLE
Spare the comparison and replace with regex

### DIFF
--- a/.changeset/loud-llamas-turn.md
+++ b/.changeset/loud-llamas-turn.md
@@ -1,0 +1,5 @@
+---
+'@vercel/postgres': patch
+---
+
+Removed an inline condition to simplify the code just a tiny bit

--- a/.changeset/loud-llamas-turn.md
+++ b/.changeset/loud-llamas-turn.md
@@ -1,5 +1,0 @@
----
-'@vercel/postgres': patch
----
-
-Removed an inline condition to simplify the code just a tiny bit

--- a/packages/postgres/src/postgres-connection-string.ts
+++ b/packages/postgres/src/postgres-connection-string.ts
@@ -42,9 +42,7 @@ export function isLocalhostConnectionString(connectionString: string): boolean {
   try {
     // This seems silly, but we can use all of the hard work put into URL parsing
     // if we just convert `postgresql://` to `https://` and then parse it as a URL.
-    const withHttpsProtocol = connectionString.startsWith('postgresql://')
-      ? connectionString.replace('postgresql://', 'https://')
-      : connectionString;
+    const withHttpsProtocol = connectionString.replace(/^postgresql:\/\//, 'https://');
     return new URL(withHttpsProtocol).hostname === 'localhost';
   } catch (err) {
     if (err instanceof TypeError) {


### PR DESCRIPTION
Instead of checking via `.startsWith` and replacing if it is, we can do both these operations via a regular expression replace