### PR TITLE
[edge-config] Add optional tracing

### DIFF
--- a/packages/edge-config/package.json
+++ b/packages/edge-config/package.json
@@ -49,6 +49,7 @@
     "@changesets/cli": "2.26.2",
     "@edge-runtime/jest-environment": "2.3.6",
     "@edge-runtime/types": "2.2.6",
+    "@opentelemetry/api": "1.7.0",
     "@types/jest": "29.5.7",
     "@types/node": "20.8.10",
     "eslint": "8.52.0",

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -10,6 +10,7 @@ import type {
 } from './types';
 import type { Loaders, RequestContext } from './types-internal';
 import { getLoadersInstance } from './utils/get-loader-instance';
+import { trace } from './utils/tracing';
 
 export {
   parseConnectionString,
@@ -18,6 +19,8 @@ export {
   type EdgeConfigValue,
   type EmbeddedEdgeConfig,
 };
+
+export { setTracerProvider } from './utils/tracing';
 
 interface EdgeConfigClientOptions {
   /**
@@ -125,7 +128,9 @@ export function createClient(
   const loadersInstanceCache = new WeakMap<RequestContext, Loaders>();
 
   const api: Omit<EdgeConfigClient, 'connection'> = {
-    async get<T = EdgeConfigValue | undefined>(key: string): Promise<T> {
+    get: trace(async function get<T = EdgeConfigValue | undefined>(
+      key: string,
+    ): Promise<T> {
       assertIsKey(key);
       const loaders = getLoadersInstance(loaderOptions, loadersInstanceCache);
 
@@ -134,7 +139,7 @@ export function createClient(
         loaders.has.prime(key, value !== undefined);
         return clone(value);
       }) as Promise<T>;
-    },
+    }),
     async has(key): Promise<boolean> {
       assertIsKey(key);
       const loaders = getLoadersInstance(loaderOptions, loadersInstanceCache);

--- a/packages/edge-config/src/utils/fetch-with-http-cache.ts
+++ b/packages/edge-config/src/utils/fetch-with-http-cache.ts
@@ -1,4 +1,4 @@
-import { measure } from './tracing';
+import { measure, trace } from './tracing';
 
 interface CachedResponseEntry {
   etag: string;
@@ -97,7 +97,11 @@ function extractStaleIfError(cacheControlHeader: string | null): number | null {
  * This is similar to fetch, but it also implements ETag semantics, and
  * it implmenets stale-if-error semantics.
  */
-export async function fetchWithHttpCache(
+export const fetchWithHttpCache = trace(_fetchWithHttpCache, {
+  name: 'fetchWithHttpCache',
+});
+
+async function _fetchWithHttpCache(
   url: string,
   options: FetchOptions = {},
 ): Promise<ResponseWithCachedResponse> {

--- a/packages/edge-config/src/utils/fetch-with-http-cache.ts
+++ b/packages/edge-config/src/utils/fetch-with-http-cache.ts
@@ -99,6 +99,11 @@ function extractStaleIfError(cacheControlHeader: string | null): number | null {
  */
 export const fetchWithHttpCache = trace(_fetchWithHttpCache, {
   name: 'fetchWithHttpCache',
+  tagSuccess(result) {
+    return {
+      status: result.status,
+    };
+  },
 });
 
 async function _fetchWithHttpCache(

--- a/packages/edge-config/src/utils/tracing.ts
+++ b/packages/edge-config/src/utils/tracing.ts
@@ -7,8 +7,62 @@ export function setTracerProvider(tracerProvider: TracerProvider): void {
   tracer = tracerProvider.getTracer(pkgName, version);
 }
 
-export function getTracer(): Tracer | undefined {
+function getTracer(): Tracer | undefined {
   return tracer;
+}
+
+export function trace<F extends Function>(
+  fn: F,
+  options: {
+    name: string;
+    tags?: Record<string, string | number | boolean>;
+  } = {
+    name: fn.name,
+  },
+): F {
+  const traced = function (this: unknown) {
+    const args = arguments as unknown as unknown[];
+    const that = this;
+
+    const tracer = getTracer();
+    if (!tracer) return fn.apply(that, args);
+
+    const span = tracer.startSpan(options.name);
+    if (options.tags) span.setAttributes(options.tags);
+
+    try {
+      const result = fn.apply(that, args);
+
+      if (result instanceof Promise) {
+        result
+          .then(() => {
+            span.setStatus({ code: 1 }); // 1 = Ok
+          })
+          .catch((error) => {
+            span.setStatus({
+              code: 2, // 2 = Error
+              message: error instanceof Error ? error.message : undefined,
+            });
+          });
+      } else {
+        span.setStatus({ code: 1 }); // 1 = Ok
+        span.end();
+      }
+
+      return result;
+    } catch (error) {
+      span.setStatus({
+        code: 2, // 2 = Error
+        message: error instanceof Error ? error.message : undefined,
+      });
+
+      span.end();
+
+      throw error;
+    }
+  };
+
+  return traced as unknown as F;
 }
 
 export function measure(label: string): (reason?: string) => void {

--- a/packages/edge-config/src/utils/tracing.ts
+++ b/packages/edge-config/src/utils/tracing.ts
@@ -1,21 +1,25 @@
-import type { TracerProvider, Tracer } from '@opentelemetry/api';
+import type { TracerProvider, Tracer, Attributes } from '@opentelemetry/api';
 import { name as pkgName, version } from '../../package.json';
 
-let tracer: Tracer | undefined;
+let tracer: TracerProvider | undefined;
 
 export function setTracerProvider(tracerProvider: TracerProvider): void {
-  tracer = tracerProvider.getTracer(pkgName, version);
+  tracer = tracerProvider;
 }
 
 function getTracer(): Tracer | undefined {
-  return tracer;
+  return tracer?.getTracer(pkgName, version);
 }
 
-export function trace<F extends Function>(
+export function trace<F extends (...args: any) => any>(
   fn: F,
   options: {
     name: string;
     tags?: Record<string, string | number | boolean>;
+    tagSuccess?: (
+      result: ReturnType<F> extends PromiseLike<infer U> ? U : ReturnType<F>,
+    ) => Attributes;
+    tagError?: (error: Error) => Attributes;
   } = {
     name: fn.name,
   },
@@ -27,39 +31,49 @@ export function trace<F extends Function>(
     const tracer = getTracer();
     if (!tracer) return fn.apply(that, args);
 
-    const span = tracer.startSpan(options.name);
-    if (options.tags) span.setAttributes(options.tags);
+    return tracer.startActiveSpan(options.name, (span) => {
+      if (options.tags) span.setAttributes(options.tags);
 
-    try {
-      const result = fn.apply(that, args);
+      try {
+        const result = fn.apply(that, args);
 
-      if (result instanceof Promise) {
-        result
-          .then(() => {
-            span.setStatus({ code: 1 }); // 1 = Ok
-          })
-          .catch((error) => {
-            span.setStatus({
-              code: 2, // 2 = Error
-              message: error instanceof Error ? error.message : undefined,
+        if (result instanceof Promise) {
+          result
+            .then((value) => {
+              if (options.tagSuccess)
+                span.setAttributes(options.tagSuccess(value));
+              span.setStatus({ code: 1 }); // 1 = Ok
+              span.end();
+            })
+            .catch((error) => {
+              if (options.tagError) span.setAttributes(options.tagError(error));
+              span.setStatus({
+                code: 2, // 2 = Error
+                message: error instanceof Error ? error.message : undefined,
+              });
+              span.end();
             });
-          });
-      } else {
-        span.setStatus({ code: 1 }); // 1 = Ok
+        } else {
+          if (options.tagSuccess)
+            span.setAttributes(options.tagSuccess(result));
+          span.setStatus({ code: 1 }); // 1 = Ok
+          span.end();
+        }
+
+        return result;
+      } catch (error: any) {
+        if (options.tagError) span.setAttributes(options.tagError(error));
+
+        span.setStatus({
+          code: 2, // 2 = Error
+          message: error instanceof Error ? error.message : undefined,
+        });
+
         span.end();
+
+        throw error;
       }
-
-      return result;
-    } catch (error) {
-      span.setStatus({
-        code: 2, // 2 = Error
-        message: error instanceof Error ? error.message : undefined,
-      });
-
-      span.end();
-
-      throw error;
-    }
+    });
   };
 
   return traced as unknown as F;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       '@edge-runtime/types':
         specifier: 2.2.6
         version: 2.2.6
+      '@opentelemetry/api':
+        specifier: 1.7.0
+        version: 1.7.0
       '@types/jest':
         specifier: 29.5.7
         version: 29.5.7
@@ -1683,6 +1686,11 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
+
+  /@opentelemetry/api@1.7.0:
+    resolution: {integrity: sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==}
+    engines: {node: '>=8.0.0'}
+    dev: true
 
   /@pkgr/utils@2.4.2:
     resolution: {integrity: sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==}


### PR DESCRIPTION
 - Exports the `setTracerProvider` to set a trace provider for the Edge Config SDK
 - Adds a tracing wrapper function
 - Wraps the most critical functions to ensure they get traced

Haven't added any tests yet, but confirmed it works by running it with a local setup.

No Changeset because it merges into the `batching-and-deduping` branch.
