### PR TITLE
fix postgres-connection-string formatting

### DIFF
--- a/packages/postgres/src/postgres-connection-string.ts
+++ b/packages/postgres/src/postgres-connection-string.ts
@@ -42,7 +42,10 @@ export function isLocalhostConnectionString(connectionString: string): boolean {
   try {
     // This seems silly, but we can use all of the hard work put into URL parsing
     // if we just convert `postgresql://` to `https://` and then parse it as a URL.
-    const withHttpsProtocol = connectionString.replace(/^postgresql:\/\//, 'https://');
+    const withHttpsProtocol = connectionString.replace(
+      /^postgresql:\/\//,
+      'https://',
+    );
     return new URL(withHttpsProtocol).hostname === 'localhost';
   } catch (err) {
     if (err instanceof TypeError) {


### PR DESCRIPTION
gets rid of a prettier linting issue causing ci to fail