### PR TITLE
fix(blob): ensure fetch is bound to browser

### DIFF
--- a/.changeset/chatty-pants-walk.md
+++ b/.changeset/chatty-pants-walk.md
@@ -1,0 +1,5 @@
+---
+"@vercel/blob": patch
+---
+
+Ensure fetch is bound to globalThis

--- a/packages/blob/src/undici-browser.js
+++ b/packages/blob/src/undici-browser.js
@@ -5,4 +5,4 @@
 // moving forward we will have to solve this problem in a more robust way
 // reusing https://github.com/inrupt/universal-fetch
 // or seeing how/if cross-fetch solves https://github.com/lquixada/cross-fetch/issues/69
-export const fetch = globalThis.fetch;
+export const fetch = globalThis.fetch.bind(globalThis);


### PR DESCRIPTION
Ensures fetch is always bound to window in the browser context.

Related data:
- Stackoverflow explanation: https://stackoverflow.com/questions/69876859/why-does-bind-fix-failed-to-execute-fetch-on-window-illegal-invocation-err
- Slack thread on issue running with Turbopack: https://vercel.slack.com/archives/C046HAU4H7F/p1702044282993239

Fixes PACK-2146
