### PR TITLE
refactor(blob): remove undici fetch

### DIFF
--- a/packages/blob/jest/setup.js
+++ b/packages/blob/jest/setup.js
@@ -2,11 +2,6 @@
 // but they are available everywhere else.
 // See https://stackoverflow.com/questions/68468203/why-am-i-getting-textencoder-is-not-defined-in-jest
 const { TextEncoder, TextDecoder } = require('node:util');
-// eslint-disable-next-line import/order -- On purpose to make requiring undici work
 const { ReadableStream } = require('node:stream/web');
 
 Object.assign(global, { TextDecoder, TextEncoder, ReadableStream });
-
-const { Request, Response } = require('undici');
-
-Object.assign(global, { Request, Response });

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -24,7 +24,6 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "browser": {
-    "undici": "./dist/undici-browser.js",
     "crypto": "./dist/crypto-browser.js",
     "stream": "./dist/stream-browser.js"
   },
@@ -63,8 +62,7 @@
     "async-retry": "^1.3.3",
     "is-buffer": "^2.0.5",
     "is-node-process": "^1.2.0",
-    "throttleit": "^2.1.0",
-    "undici": "^5.28.4"
+    "throttleit": "^2.1.0"
   },
   "devDependencies": {
     "@edge-runtime/jest-environment": "2.3.10",

--- a/packages/blob/src/api.node.test.ts
+++ b/packages/blob/src/api.node.test.ts
@@ -1,4 +1,3 @@
-import undici from 'undici';
 import {
   BlobAccessError,
   BlobNotFoundError,
@@ -12,6 +11,8 @@ import {
 import { BlobError } from './helpers';
 
 describe('api', () => {
+  const fetchMock = jest.fn();
+
   describe('request api', () => {
     const OLD_ENV = process.env;
 
@@ -21,16 +22,16 @@ describe('api', () => {
       jest.restoreAllMocks();
 
       process.env = { ...OLD_ENV };
+
+      globalThis.fetch = fetchMock;
     });
 
     it('should throw if no token is provided', async () => {
-      const fetchMock = jest.spyOn(undici, 'fetch').mockImplementation(
-        jest.fn().mockResolvedValue({
-          status: 200,
-          ok: true,
-          json: () => Promise.resolve({ success: true }),
-        }),
-      );
+      fetchMock.mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve({ success: true }),
+      });
 
       process.env.BLOB_READ_WRITE_TOKEN = undefined;
 
@@ -42,13 +43,11 @@ describe('api', () => {
     });
 
     it('should not retry successful request', async () => {
-      const fetchMock = jest.spyOn(undici, 'fetch').mockImplementation(
-        jest.fn().mockResolvedValue({
-          status: 200,
-          ok: true,
-          json: () => Promise.resolve({ success: true }),
-        }),
-      );
+      fetchMock.mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve({ success: true }),
+      });
 
       const res = await requestApi<{ success: boolean }>(
         '/method',
@@ -81,13 +80,11 @@ describe('api', () => {
     ])(
       `should retry '%s %s' error response`,
       async (status, code, error) => {
-        const fetchMock = jest.spyOn(undici, 'fetch').mockImplementation(
-          jest.fn().mockResolvedValue({
-            status,
-            ok: false,
-            json: () => Promise.resolve({ error: { code } }),
-          }),
-        );
+        fetchMock.mockResolvedValue({
+          status,
+          ok: false,
+          json: () => Promise.resolve({ error: { code } }),
+        });
 
         process.env.VERCEL_BLOB_RETRIES = '1';
         process.env.BLOB_READ_WRITE_TOKEN = 'test-token';
@@ -118,13 +115,11 @@ describe('api', () => {
     ])(
       `should not retry '%s %s' response error response`,
       async (status, code, error, message = '') => {
-        const fetchMock = jest.spyOn(undici, 'fetch').mockImplementation(
-          jest.fn().mockResolvedValue({
-            status,
-            ok: false,
-            json: () => Promise.resolve({ error: { code, message } }),
-          }),
-        );
+        fetchMock.mockResolvedValue({
+          status,
+          ok: false,
+          json: () => Promise.resolve({ error: { code, message } }),
+        });
 
         await expect(
           requestApi('/api', { method: 'GET' }, { token: '123' }),

--- a/packages/blob/src/api.ts
+++ b/packages/blob/src/api.ts
@@ -1,4 +1,3 @@
-import type { Response } from 'undici';
 import retry from 'async-retry';
 import isNetworkError from './is-network-error';
 import { debug } from './debug';

--- a/packages/blob/src/client.browser.test.ts
+++ b/packages/blob/src/client.browser.test.ts
@@ -1,4 +1,3 @@
-import undici from 'undici';
 import {
   completeMultipartUpload,
   createMultipartUpload,
@@ -9,6 +8,7 @@ import {
 } from './client';
 
 describe('client', () => {
+  const fetchMock = jest.fn();
   let requestId = '';
 
   beforeEach(() => {
@@ -24,6 +24,8 @@ describe('client', () => {
 
     jest.spyOn(global.Math, 'random').mockReturnValue(Math.random());
     requestId = Math.random().toString(16).slice(2);
+
+    global.fetch = fetchMock;
   });
 
   afterEach(() => {
@@ -31,32 +33,30 @@ describe('client', () => {
   });
 
   describe('upload()', () => {
-    it('should upload a file from the client', async () => {
-      const fetchMock = jest.spyOn(undici, 'fetch').mockImplementation(
-        jest
-          .fn()
-          .mockResolvedValueOnce({
-            status: 200,
-            ok: true,
-            json: () =>
-              Promise.resolve({
-                type: 'blob.generate-client-token',
-                clientToken: 'vercel_blob_client_fake_123',
-              }),
-          })
-          .mockResolvedValueOnce({
-            status: 200,
-            ok: true,
-            json: () =>
-              Promise.resolve({
-                url: `https://storeId.public.blob.vercel-storage.com/superfoo.txt`,
-                downloadUrl: `https://storeId.public.blob.vercel-storage.com/superfoo.txt?download=1`,
-                pathname: 'foo.txt',
-                contentType: 'text/plain',
-                contentDisposition: 'attachment; filename="foo.txt"',
-              }),
-          }),
-      );
+    it.only('should upload a file from the client', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              type: 'blob.generate-client-token',
+              clientToken: 'vercel_blob_client_fake_123',
+            }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              url: 'https://storeId.public.blob.vercel-storage.com/superfoo.txt',
+              downloadUrl:
+                'https://storeId.public.blob.vercel-storage.com/superfoo.txt?download=1',
+              pathname: 'foo.txt',
+              contentType: 'text/plain',
+              contentDisposition: 'attachment; filename="foo.txt"',
+            }),
+        });
 
       await expect(
         upload('foo.txt', 'Test file data', {
@@ -118,36 +118,33 @@ describe('client', () => {
     });
 
     it('should upload a file using the manual functions', async () => {
-      const fetchMock = jest.spyOn(undici, 'fetch').mockImplementation(
-        jest
-          .fn()
-          .mockResolvedValueOnce({
-            status: 200,
-            ok: true,
-            json: () => Promise.resolve({ key: 'key', uploadId: 'uploadId' }),
-          })
-          .mockResolvedValueOnce({
-            status: 200,
-            ok: true,
-            json: () => Promise.resolve({ etag: 'etag1' }),
-          })
-          .mockResolvedValueOnce({
-            status: 200,
-            ok: true,
-            json: () => Promise.resolve({ etag: 'etag2' }),
-          })
-          .mockResolvedValueOnce({
-            status: 200,
-            ok: true,
-            json: () =>
-              Promise.resolve({
-                url: `https://storeId.public.blob.vercel-storage.com/foo.txt`,
-                pathname: 'foo.txt',
-                contentType: 'text/plain',
-                contentDisposition: 'attachment; filename="foo.txt"',
-              }),
-          }),
-      );
+      fetchMock
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          json: () => Promise.resolve({ key: 'key', uploadId: 'uploadId' }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          json: () => Promise.resolve({ etag: 'etag1' }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          json: () => Promise.resolve({ etag: 'etag2' }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              url: 'https://storeId.public.blob.vercel-storage.com/foo.txt',
+              pathname: 'foo.txt',
+              contentType: 'text/plain',
+              contentDisposition: 'attachment; filename="foo.txt"',
+            }),
+        });
 
       const pathname = 'foo.txt';
       const token = 'vercel_blob_client_fake_token_for_test';
@@ -278,36 +275,33 @@ describe('client', () => {
     });
 
     it('should upload a file using the uploader', async () => {
-      const fetchMock = jest.spyOn(undici, 'fetch').mockImplementation(
-        jest
-          .fn()
-          .mockResolvedValueOnce({
-            status: 200,
-            ok: true,
-            json: () => Promise.resolve({ key: 'key', uploadId: 'uploadId' }),
-          })
-          .mockResolvedValueOnce({
-            status: 200,
-            ok: true,
-            json: () => Promise.resolve({ etag: 'etag1' }),
-          })
-          .mockResolvedValueOnce({
-            status: 200,
-            ok: true,
-            json: () => Promise.resolve({ etag: 'etag2' }),
-          })
-          .mockResolvedValueOnce({
-            status: 200,
-            ok: true,
-            json: () =>
-              Promise.resolve({
-                url: `https://storeId.public.blob.vercel-storage.com/foo.txt`,
-                pathname: 'foo.txt',
-                contentType: 'text/plain',
-                contentDisposition: 'attachment; filename="foo.txt"',
-              }),
-          }),
-      );
+      fetchMock
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          json: () => Promise.resolve({ key: 'key', uploadId: 'uploadId' }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          json: () => Promise.resolve({ etag: 'etag1' }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          json: () => Promise.resolve({ etag: 'etag2' }),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              url: 'https://storeId.public.blob.vercel-storage.com/foo.txt',
+              pathname: 'foo.txt',
+              contentType: 'text/plain',
+              contentDisposition: 'attachment; filename="foo.txt"',
+            }),
+        });
 
       const pathname = 'foo.txt';
       const token = 'vercel_blob_client_fake_token_for_test';
@@ -421,13 +415,11 @@ describe('client', () => {
 
     it('should reject incorrect body in uploader.uploadPart()', async () => {
       // Mock the createMultipartUploader to return a minimal uploader object
-      jest.spyOn(undici, 'fetch').mockImplementation(
-        jest.fn().mockResolvedValueOnce({
-          status: 200,
-          ok: true,
-          json: () => Promise.resolve({ key: 'key', uploadId: 'uploadId' }),
-        }),
-      );
+      fetchMock.mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve({ key: 'key', uploadId: 'uploadId' }),
+      });
 
       const uploader = await createMultipartUploader('foo.txt', {
         access: 'public',
@@ -469,6 +461,7 @@ describe('client', () => {
             {
               access: 'public',
               multipart: true,
+              token: '123',
             },
           ),
       ],

--- a/packages/blob/src/client.ts
+++ b/packages/blob/src/client.ts
@@ -1,10 +1,6 @@
 // eslint-disable-next-line unicorn/prefer-node-protocol -- node:crypto does not resolve correctly in browser and edge runtime
 import * as crypto from 'crypto';
 import type { IncomingMessage } from 'node:http';
-// When bundled via a bundler supporting the `browser` field, then
-// the `undici` module will be replaced with https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
-// for browser contexts. See ./undici-browser.js and ./package.json
-import { fetch } from 'undici';
 import type { BlobCommandOptions, WithUploadProgress } from './helpers';
 import { BlobError, getTokenFromOptionsOrEnv } from './helpers';
 import { createPutMethod } from './put';
@@ -384,7 +380,7 @@ function hexToArrayByte(input: string): Buffer {
   const view = new Uint8Array(input.length / 2);
 
   for (let i = 0; i < input.length; i += 2) {
-    view[i / 2] = parseInt(input.substring(i, i + 2), 16);
+    view[i / 2] = Number.parseInt(input.substring(i, i + 2), 16);
   }
 
   return Buffer.from(view);

--- a/packages/blob/src/fetch.ts
+++ b/packages/blob/src/fetch.ts
@@ -1,5 +1,3 @@
-import type { BodyInit } from 'undici';
-import { fetch } from 'undici';
 import type { BlobRequest } from './helpers';
 import {
   createChunkTransformStream,
@@ -52,13 +50,10 @@ export const blobFetch: BlobRequest = async ({
       ? 'half'
       : undefined;
 
-  return fetch(
-    input,
-    // @ts-expect-error -- Blob and Nodejs Blob are triggering type errors, fine with it
-    {
-      ...init,
-      ...(init.body ? { body } : {}),
-      duplex,
-    },
-  );
+  return fetch(input, {
+    ...init,
+    ...(init.body ? { body } : {}),
+    // @ts-expect-error -- not typed
+    duplex,
+  });
 };

--- a/packages/blob/src/helpers.ts
+++ b/packages/blob/src/helpers.ts
@@ -2,7 +2,6 @@
 // this is why it's not exported from index/client
 
 import type { Readable } from 'node:stream';
-import type { RequestInit, Response } from 'undici';
 import { isNodeProcess } from 'is-node-process';
 import { isNodeJsReadableStream } from './multipart/helpers';
 import type { PutBody } from './put-helpers';

--- a/packages/blob/src/multipart/upload.ts
+++ b/packages/blob/src/multipart/upload.ts
@@ -109,7 +109,6 @@ export async function uploadPart({
         'x-mpu-upload-id': uploadId,
         'x-mpu-part-number': part.partNumber.toString(),
       },
-      // weird things between undici types and native fetch types
       body: part.blob,
     },
     options,

--- a/packages/blob/src/put-helpers.ts
+++ b/packages/blob/src/put-helpers.ts
@@ -1,9 +1,5 @@
 // eslint-disable-next-line unicorn/prefer-node-protocol -- node:stream does not resolve correctly in browser and edge
 import type { Readable } from 'stream';
-// We use the undici types to ensure TS doesn't complain about native types (like ReadableStream) vs
-// undici types fetch expects (like Blob is from node:buffer..)
-// import type { Blob } from 'node:buffer';
-import type { File } from 'undici';
 import type { ClientCommonCreateBlobOptions } from './client';
 import type { CommonCreateBlobOptions } from './helpers';
 import { BlobError, disallowedPathnameCharacters } from './helpers';

--- a/packages/blob/src/request.ts
+++ b/packages/blob/src/request.ts
@@ -1,4 +1,3 @@
-import type { Response } from 'undici';
 import { blobFetch, hasFetch, hasFetchWithUploadProgress } from './fetch';
 import { hasXhr, blobXhr } from './xhr';
 import type { BlobRequest } from './helpers';
@@ -17,6 +16,9 @@ export const blobRequest: BlobRequest = async ({
       return blobXhr({ input, init, onUploadProgress });
     }
   }
+
+  console.log('hasFetch', hasFetch);
+  console.log('hasXhr', hasXhr);
 
   if (hasFetch) {
     return blobFetch({ input, init });

--- a/packages/blob/src/undici-browser.js
+++ b/packages/blob/src/undici-browser.js
@@ -1,8 +1,0 @@
-// this file gets copied to the dist folder
-// it makes undici work in the browser by reusing the global fetch
-// it's the simplest way I've found to make http requests work in Node.js, Serverles Functions, Edge Functions, and the browser
-// this should work as long as this module is used via Next.js/Webpack
-// moving forward we will have to solve this problem in a more robust way
-// reusing https://github.com/inrupt/universal-fetch
-// or seeing how/if cross-fetch solves https://github.com/lquixada/cross-fetch/issues/69
-export const fetch = globalThis.fetch.bind(globalThis);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,6 @@ importers:
       throttleit:
         specifier: ^2.1.0
         version: 2.1.0
-      undici:
-        specifier: ^5.28.4
-        version: 5.28.4
     devDependencies:
       '@edge-runtime/jest-environment':
         specifier: 2.3.10
@@ -1137,10 +1134,6 @@ packages:
   '@eslint/js@8.56.0':
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -5446,10 +5439,6 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
-  undici@5.28.4:
-    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
-    engines: {node: '>=14.0'}
-
   undici@6.20.1:
     resolution: {integrity: sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==}
     engines: {node: '>=18.17'}
@@ -6510,8 +6499,6 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.56.0': {}
-
-  '@fastify/busboy@2.1.1': {}
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -11915,10 +11902,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.20.0: {}
-
-  undici@5.28.4:
-    dependencies:
-      '@fastify/busboy': 2.1.1
 
   undici@6.20.1: {}
 

--- a/test/next/src/app/vercel/blob/script.mts
+++ b/test/next/src/app/vercel/blob/script.mts
@@ -6,7 +6,6 @@
 import { createReadStream, readFile, readFileSync } from 'node:fs';
 import type { IncomingMessage } from 'node:http';
 import https from 'node:https';
-import { fetch } from 'undici';
 import axios from 'axios';
 import got from 'got';
 import * as vercelBlob from '@vercel/blob';


### PR DESCRIPTION
Node.js 16 is deprecated since January 31, 2025. We can remove the undici dependency now and rely on the node.js fetch.

https://vercel.com/changelog/node-js-16-deprecation