### PR TITLE
[@vercel/edge-config] Improve error handling and forwarding

### DIFF
--- a/packages/edge-config/src/index.edge.test.ts
+++ b/packages/edge-config/src/index.edge.test.ts
@@ -130,11 +130,9 @@ describe('default Edge Config', () => {
 
     describe('when the network fails', () => {
       it('should throw a Network error', async () => {
-        fetchMock.mockReject();
+        fetchMock.mockReject(new Error('Unexpected fetch error'));
 
-        await expect(get('foo')).rejects.toThrow(
-          '@vercel/edge-config: Network error',
-        );
+        await expect(get('foo')).rejects.toThrow('Unexpected fetch error');
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(
@@ -157,7 +155,7 @@ describe('default Edge Config', () => {
         fetchMock.mockResponse('', { status: 500 });
 
         await expect(get('foo')).rejects.toThrow(
-          '@vercel/edge-config: Unexpected error',
+          '@vercel/edge-config: Unexpected error due to response with status code 500',
         );
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -256,11 +254,9 @@ describe('default Edge Config', () => {
 
     describe('when the network fails', () => {
       it('should throw a Network error', async () => {
-        fetchMock.mockReject();
+        fetchMock.mockReject(new Error('Unexpected fetch error'));
 
-        await expect(getAll()).rejects.toThrow(
-          '@vercel/edge-config: Network error',
-        );
+        await expect(getAll()).rejects.toThrow('Unexpected fetch error');
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
@@ -280,7 +276,7 @@ describe('default Edge Config', () => {
         fetchMock.mockResponse('', { status: 500 });
 
         await expect(getAll()).rejects.toThrow(
-          '@vercel/edge-config: Unexpected error',
+          '@vercel/edge-config: Unexpected error due to response with status code 500',
         );
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -417,7 +413,7 @@ describe('default Edge Config', () => {
         fetchMock.mockResponse('', { status: 500 });
 
         await expect(digest()).rejects.toThrow(
-          '@vercel/edge-config: Unexpected error',
+          '@vercel/edge-config: Unexpected error due to response with status code 500',
         );
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -436,7 +432,7 @@ describe('default Edge Config', () => {
         fetchMock.mockResponse('', { status: 404 });
 
         await expect(digest()).rejects.toThrow(
-          '@vercel/edge-config: Unexpected error',
+          '@vercel/edge-config: Unexpected error due to response with status code 404',
         );
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -454,11 +450,9 @@ describe('default Edge Config', () => {
 
     describe('when the network fails', () => {
       it('should throw a Network error', async () => {
-        fetchMock.mockReject();
+        fetchMock.mockReject(new Error('Unexpected fetch error'));
 
-        await expect(digest()).rejects.toThrow(
-          '@vercel/edge-config: Network error',
-        );
+        await expect(digest()).rejects.toThrow('Unexpected fetch error');
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {

--- a/packages/edge-config/src/index.node.test.ts
+++ b/packages/edge-config/src/index.node.test.ts
@@ -147,11 +147,9 @@ describe('default Edge Config', () => {
 
     describe('when the network fails', () => {
       it('should throw a Network error', async () => {
-        fetchMock.mockReject();
+        fetchMock.mockReject(new Error('Unexpected fetch error'));
 
-        await expect(get('foo')).rejects.toThrow(
-          '@vercel/edge-config: Network error',
-        );
+        await expect(get('foo')).rejects.toThrow('Unexpected fetch error');
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(
@@ -174,7 +172,7 @@ describe('default Edge Config', () => {
         fetchMock.mockResponse('', { status: 500 });
 
         await expect(get('foo')).rejects.toThrow(
-          '@vercel/edge-config: Unexpected error',
+          '@vercel/edge-config: Unexpected error due to response with status code 500',
         );
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -273,11 +271,9 @@ describe('default Edge Config', () => {
 
     describe('when the network fails', () => {
       it('should throw a Network error', async () => {
-        fetchMock.mockReject();
+        fetchMock.mockReject(new Error('Unexpected fetch error'));
 
-        await expect(getAll()).rejects.toThrow(
-          '@vercel/edge-config: Network error',
-        );
+        await expect(getAll()).rejects.toThrow('Unexpected fetch error');
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/items?version=1`, {
@@ -297,7 +293,7 @@ describe('default Edge Config', () => {
         fetchMock.mockResponse('', { status: 500 });
 
         await expect(getAll()).rejects.toThrow(
-          '@vercel/edge-config: Unexpected error',
+          '@vercel/edge-config: Unexpected error due to response with status code 500',
         );
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -434,7 +430,7 @@ describe('default Edge Config', () => {
         fetchMock.mockResponse('', { status: 500 });
 
         await expect(digest()).rejects.toThrow(
-          '@vercel/edge-config: Unexpected error',
+          '@vercel/edge-config: Unexpected error due to response with status code 500',
         );
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -453,7 +449,7 @@ describe('default Edge Config', () => {
         fetchMock.mockResponse('', { status: 404 });
 
         await expect(digest()).rejects.toThrow(
-          '@vercel/edge-config: Unexpected error',
+          '@vercel/edge-config: Unexpected error due to response with status code 404',
         );
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -471,11 +467,9 @@ describe('default Edge Config', () => {
 
     describe('when the network fails', () => {
       it('should throw a Network error', async () => {
-        fetchMock.mockReject();
+        fetchMock.mockReject(new Error('Unexpected fetch error'));
 
-        await expect(digest()).rejects.toThrow(
-          '@vercel/edge-config: Network error',
-        );
+        await expect(digest()).rejects.toThrow('Unexpected fetch error');
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(`${baseUrl}/digest?version=1`, {

--- a/packages/edge-config/src/utils/index.ts
+++ b/packages/edge-config/src/utils/index.ts
@@ -2,11 +2,17 @@ import type { Connection } from '../types';
 import { trace } from './tracing';
 
 export const ERRORS = {
-  UNEXPECTED: '@vercel/edge-config: Unexpected error',
   UNAUTHORIZED: '@vercel/edge-config: Unauthorized',
-  NETWORK: '@vercel/edge-config: Network error',
   EDGE_CONFIG_NOT_FOUND: '@vercel/edge-config: Edge Config not found',
 };
+
+export class UnexpectedNetworkError extends Error {
+  constructor(res: Response) {
+    super(
+      `@vercel/edge-config: Unexpected error due to response with status code ${res.status}`,
+    );
+  }
+}
 
 /**
  * Checks if an object has a property
@@ -162,27 +168,3 @@ export function parseConnectionString(
   if (connection) return connection;
   return parseExternalConnectionString(connectionString);
 }
-
-/**
- * Works around an issue in Next.js.
- *
- * Next.js problematically expects to be able to throw DynamicServerError and
- * for it to be passed all the way upwards, but we are catching all errors and
- * mapping them to a generic NetworkError.
- *
- * We do this catch-all to prevent leaky abstractions.
- * Otherwise we might leak our implementation details through errors.
- *
- * But this breaks Next.js. So we need to make an exception for it until Next.js
- * no longer expects this behavior.
- *
- * Without this fix, Next.js would fail builds of in which edge config is read
- * from async page components.
- *
- * https://github.com/vercel/storage/issues/119
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- [@vercel/style-guide@5 migration]
-export const isDynamicServerError = (error: any): boolean =>
-  error instanceof Error &&
-  hasOwnProperty(error, 'digest') &&
-  error.digest === 'DYNAMIC_SERVER_USAGE';


### PR DESCRIPTION
Slightly improve the error handling in `@vercel/edge-config`:

 - Adds the status code to the `Unexpected error` for more clarity when possible
 - Forward unhandled errors as they are instead of replacing them with `Network error`

This should make things more clear whenever an error happens with regards to the Edge Config SDK.

Adding no Changeset to group multiple changes into one release later on.