### PR TITLE
[edge-config] Fix SWR in Edge Config development cache

### DIFF
--- a/packages/edge-config/src/utils/swr-fn.test.ts
+++ b/packages/edge-config/src/utils/swr-fn.test.ts
@@ -108,4 +108,15 @@ describe('swr-fn', () => {
     await expect(swrFn()).resolves.toEqual(['a']);
     fn.mockResolvedValueOnce([]);
   });
+
+  it('should not return a different value', async () => {
+    const myMap: Record<string, number> = { a: 70, b: 1337 };
+    const getter = (key: string): Promise<number | undefined> =>
+      Promise.resolve(myMap[key]);
+
+    const swrFn = swr(getter);
+
+    expect(await swrFn('a')).toBe(70);
+    expect(await swrFn('b')).toBe(1337);
+  });
 });


### PR DESCRIPTION
Fixes a bug in the SWR functionality for Edge Config that is used during development.

At the moment, we don't consider the argument, causing the e.g. `get` function to always return the most recent promise. With this fix, we'll make sure to only return the value if the arguments of the function match.

No Changeset to make it part of the 1.0.0 release.
