### PR TITLE
prevent too many open connections

### DIFF
--- a/.changeset/healthy-dots-care.md
+++ b/.changeset/healthy-dots-care.md
@@ -1,0 +1,5 @@
+---
+"@vercel/edge-config": patch
+---
+
+prevents having too many open connections


### PR DESCRIPTION
So far we were consuming the response body in Node.js to prevent running out of memory, but Workers also require response bodies to get consumed to avoid having too many connections open simultaneously. A connection counts as open until the response body is read. So we must always consume it, even if we do not use it.

**_Testing this as a snapshot release for now, before we merge and publish._**