### PR TITLE
fix(deps): configure `peerDependenciesMeta`

### DIFF
--- a/packages/edge-config/package.json
+++ b/packages/edge-config/package.json
@@ -64,6 +64,11 @@
   "peerDependencies": {
     "@opentelemetry/api": "^1.7.0"
   },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=14.6"
   }


### PR DESCRIPTION
Fixes #606

This PR informs package managers that `@opentelemetry/api` is an optional peer dependency[^1] by adding `peerDependenciesMeta` and marking `@opentelemetry/api` as optional.

[^1]: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependenciesmeta
