### PR TITLE
fix(blob): correctly handle Node.js buffers as input

### DIFF
--- a/.changeset/brown-pandas-promise.md
+++ b/.changeset/brown-pandas-promise.md
@@ -1,0 +1,5 @@
+---
+"@vercel/blob": patch
+---
+
+fix(blob): correctly handle Node.js buffers as input

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "async-retry": "1.3.3",
     "bytes": "3.1.2",
+    "is-buffer": "2.0.5",
     "undici": "5.28.2"
   },
   "devDependencies": {

--- a/packages/blob/src/put-helpers.ts
+++ b/packages/blob/src/put-helpers.ts
@@ -23,6 +23,7 @@ export type PutBlobApiResponse = PutBlobResult;
 export type PutBody =
   | string
   | Readable // Node.js streams
+  | Buffer // Node.js buffers
   | Blob
   | ArrayBuffer
   | ReadableStream // Streams API (= Web streams in Node.js)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       bytes:
         specifier: 3.1.2
         version: 3.1.2
+      is-buffer:
+        specifier: 2.0.5
+        version: 2.0.5
       undici:
         specifier: 5.28.2
         version: 5.28.2
@@ -4853,6 +4856,11 @@ packages:
     dependencies:
       call-bind: 1.0.5
       has-tostringtag: 1.0.0
+
+  /is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+    dev: false
 
   /is-builtin-module@3.2.1:
     resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}

--- a/test/next/src/app/vercel/blob/app/body/serverless/page.tsx
+++ b/test/next/src/app/vercel/blob/app/body/serverless/page.tsx
@@ -27,7 +27,7 @@ export default function AppFormDataServerless(): JSX.Element {
       <p>
         Note: When deployed on Vercel, there&apos;s a 4.5 MB file upload limit.
       </p>
-      <FormBodyUpload action="/vercel/blob/api/app/body/edge" />
+      <FormBodyUpload action="/vercel/blob/api/app/body/serverless" />
     </>
   );
 }

--- a/test/next/src/app/vercel/blob/handle-body.ts
+++ b/test/next/src/app/vercel/blob/handle-body.ts
@@ -6,6 +6,7 @@ export async function handleBody(request: Request): Promise<NextResponse> {
   const { searchParams } = new URL(request.url);
   const pathname = searchParams.get('filename');
   const multipart = searchParams.get('multipart') === '1';
+  const useBuffer = searchParams.get('useBuffer') === '1';
 
   if (!request.body || pathname === null) {
     return NextResponse.json(
@@ -25,8 +26,16 @@ export async function handleBody(request: Request): Promise<NextResponse> {
     );
   }
 
+  let body: ReadableStream | Buffer;
+
+  if (useBuffer) {
+    body = Buffer.from(await request.arrayBuffer());
+  } else {
+    body = request.body;
+  }
+
   // Note: this will stream the file to Vercel's Blob Store
-  const blob = await vercelBlob.put(pathname, request.body, {
+  const blob = await vercelBlob.put(pathname, body, {
     access: 'public',
     multipart,
   });

--- a/test/next/test/@vercel/blob/index.test.ts
+++ b/test/next/test/@vercel/blob/index.test.ts
@@ -1,4 +1,6 @@
 import crypto from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { test, expect } from '@playwright/test';
 import type { PutBlobResult } from '@vercel/blob';
 
@@ -150,22 +152,22 @@ test.describe('@vercel/blob', () => {
         });
       });
 
+      // https://github.com/vercel/storage/pull/616
       test('multipart upload with buffer', async ({ request }) => {
         const path = 'vercel/blob/api/app/body/serverless';
+        const imgPath = join(process.cwd(), 'images');
+        const imageFile = readFileSync(join(imgPath, `g.jpeg`));
 
         const data = (await request
-          .post(`${path}?filename=${prefix}/test.txt&multipart=1&useBuffer=1`, {
-            data: `Hello world ${path} ${prefix}`,
+          .post(`${path}?filename=${prefix}/g.jpeg&multipart=1&useBuffer=1`, {
+            data: imageFile,
             headers: {
               cookie: `clientUpload=${process.env.BLOB_UPLOAD_SECRET ?? ''}`,
             },
           })
           .then((r) => r.json())) as PutBlobResult;
-        expect(data.contentDisposition).toBe('inline; filename="test.txt"');
-        expect(data.contentType).toBe('text/plain');
-        expect(data.pathname).toBe(`${prefix}/test.txt`);
-        const content = await request.get(data.url).then((r) => r.text());
-        expect(content).toBe(`Hello world ${path} ${prefix}`);
+        const content = await request.head(data.url);
+        expect(content.headers()['content-length']).toEqual('19939');
       });
     });
   });

--- a/test/next/test/@vercel/blob/index.test.ts
+++ b/test/next/test/@vercel/blob/index.test.ts
@@ -149,6 +149,24 @@ test.describe('@vercel/blob', () => {
           });
         });
       });
+
+      test('multipart upload with buffer', async ({ request }) => {
+        const path = 'vercel/blob/api/app/body/serverless';
+
+        const data = (await request
+          .post(`${path}?filename=${prefix}/test.txt&multipart=1&useBuffer=1`, {
+            data: `Hello world ${path} ${prefix}`,
+            headers: {
+              cookie: `clientUpload=${process.env.BLOB_UPLOAD_SECRET ?? ''}`,
+            },
+          })
+          .then((r) => r.json())) as PutBlobResult;
+        expect(data.contentDisposition).toBe('inline; filename="test.txt"');
+        expect(data.contentType).toBe('text/plain');
+        expect(data.pathname).toBe(`${prefix}/test.txt`);
+        const content = await request.get(data.url).then((r) => r.text());
+        expect(content).toBe(`Hello world ${path} ${prefix}`);
+      });
     });
   });
 


### PR DESCRIPTION
Before this commit, we would treat Buffers (Node.js) as strings and would just mess up the upload completely. We did not support Buffers officially but now we do.