### PR TITLE
[edge-config] Make `@opentelemetry/api` optional and add `setTracerProvider` function

### DIFF
--- a/.changeset/popular-trees-buy.md
+++ b/.changeset/popular-trees-buy.md
@@ -1,0 +1,5 @@
+---
+"@vercel/edge-config": minor
+---
+
+Make `@opentelemetry/api` optional and expose a `setTracer` function

--- a/.changeset/popular-trees-buy.md
+++ b/.changeset/popular-trees-buy.md
@@ -2,4 +2,4 @@
 "@vercel/edge-config": minor
 ---
 
-Make `@opentelemetry/api` optional and expose a `setTracer` function
+Make `@opentelemetry/api` optional and expose a `setTracerProvider` function

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -121,7 +121,7 @@ export const config = { runtime: 'edge' };
 
 ## OpenTelemetry Tracing
 
-The `@vercel/edge-config` package makes use of the OpenTelemetry standard to trace certain functions for observability. In order to enable it, use the function `setTracer` to set the `TraceAPI` that should be used by the SDK.
+The `@vercel/edge-config` package makes use of the OpenTelemetry standard to trace certain functions for observability. In order to enable it, use the function `setTracerProvider` to set the `TracerProvider` that should be used by the SDK.
 
 ```js
 import { setTracerProvider } from '@vercel/edge-config';

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -119,6 +119,19 @@ export default (req) => {
 export const config = { runtime: 'edge' };
 ```
 
+## OpenTelemetry Tracing
+
+The `@vercel/edge-config` package makes use of the OpenTelemetry standard to trace certain functions for observability. In order to enable it, use the function `setTracer` to set the `TraceAPI` that should be used by the SDK.
+
+```js
+import { setTracer } from '@vercel/edge-config';
+import { trace } from '@opentelemetry/api';
+
+setTracer(trace);
+```
+
+More verbose traces can be enabled by setting the `EDGE_CONFIG_TRACE_VERBOSE` environment variable to `true`.
+
 ## Caught a Bug?
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -124,10 +124,10 @@ export const config = { runtime: 'edge' };
 The `@vercel/edge-config` package makes use of the OpenTelemetry standard to trace certain functions for observability. In order to enable it, use the function `setTracer` to set the `TraceAPI` that should be used by the SDK.
 
 ```js
-import { setTracer } from '@vercel/edge-config';
+import { setTracerProvider } from '@vercel/edge-config';
 import { trace } from '@opentelemetry/api';
 
-setTracer(trace);
+setTracerProvider(trace);
 ```
 
 More verbose traces can be enabled by setting the `EDGE_CONFIG_TRACE_VERBOSE` environment variable to `true`.

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -20,7 +20,7 @@ import type {
 import { fetchWithCachedResponse } from './utils/fetch-with-cached-response';
 import { trace } from './utils/tracing';
 
-export { setTracer } from './utils/tracing';
+export { setTracerProvider } from './utils/tracing';
 
 export {
   parseConnectionString,

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -20,6 +20,8 @@ import type {
 import { fetchWithCachedResponse } from './utils/fetch-with-cached-response';
 import { trace } from './utils/tracing';
 
+export { setTracer } from './utils/tracing';
+
 export {
   parseConnectionString,
   type EdgeConfigClient,

--- a/packages/edge-config/src/utils/tracing.ts
+++ b/packages/edge-config/src/utils/tracing.ts
@@ -1,12 +1,18 @@
-import {
-  trace as traceApi,
-  type Tracer,
-  type Attributes,
-} from '@opentelemetry/api';
+import type { TraceAPI, Tracer, Attributes } from '@opentelemetry/api';
 import { name as pkgName, version } from '../../package.json';
 
+let traceApi: TraceAPI | null = null;
+
+/**
+ * Allows setting the `@opentelemetry/api` tracer to generate traces
+ * for Edge Config related operations.
+ */
+export function setTracer(tracer: TraceAPI) {
+  traceApi = tracer;
+}
+
 function getTracer(): Tracer | undefined {
-  return traceApi.getTracer(pkgName, version);
+  return traceApi?.getTracer(pkgName, version);
 }
 
 function isPromise<T>(p: unknown): p is Promise<T> {

--- a/packages/edge-config/src/utils/tracing.ts
+++ b/packages/edge-config/src/utils/tracing.ts
@@ -1,4 +1,4 @@
-import type { TraceAPI, Tracer, Attributes } from '@opentelemetry/api';
+import type { Tracer, Attributes, TracerProvider } from '@opentelemetry/api';
 import { name as pkgName, version } from '../../package.json';
 
 // Use a symbol to avoid having global variable that is scoped to this file,
@@ -6,17 +6,17 @@ import { name as pkgName, version } from '../../package.json';
 const edgeConfigTraceSymbol = Symbol.for('@vercel/edge-config:global-trace');
 
 /**
- * Allows setting the `@opentelemetry/api` tracer to generate traces
+ * Allows setting the `@opentelemetry/api` tracer provider to generate traces
  * for Edge Config related operations.
  */
-export function setTracer(tracer: TraceAPI): void {
+export function setTracerProvider(tracer: TracerProvider): void {
   Reflect.set(globalThis, edgeConfigTraceSymbol, tracer);
 }
 
 function getTracer(): Tracer | undefined {
   const maybeTraceApi = Reflect.get(globalThis, edgeConfigTraceSymbol) as
     | undefined
-    | TraceAPI;
+    | TracerProvider;
   return maybeTraceApi?.getTracer(pkgName, version);
 }
 

--- a/packages/edge-config/src/utils/tracing.ts
+++ b/packages/edge-config/src/utils/tracing.ts
@@ -7,7 +7,7 @@ let traceApi: TraceAPI | null = null;
  * Allows setting the `@opentelemetry/api` tracer to generate traces
  * for Edge Config related operations.
  */
-export function setTracer(tracer: TraceAPI) {
+export function setTracer(tracer: TraceAPI): void {
   traceApi = tracer;
 }
 

--- a/packages/edge-config/src/utils/tracing.ts
+++ b/packages/edge-config/src/utils/tracing.ts
@@ -14,10 +14,9 @@ export function setTracer(tracer: TraceAPI): void {
 }
 
 function getTracer(): Tracer | undefined {
-  const maybeTraceApi: undefined | TraceAPI = Reflect.get(
-    globalThis,
-    edgeConfigTraceSymbol,
-  );
+  const maybeTraceApi = Reflect.get(globalThis, edgeConfigTraceSymbol) as
+    | undefined
+    | TraceAPI;
   return maybeTraceApi?.getTracer(pkgName, version);
 }
 

--- a/packages/edge-config/src/utils/tracing.ts
+++ b/packages/edge-config/src/utils/tracing.ts
@@ -48,13 +48,6 @@ export function trace<F extends (...args: any) => any>(
 ): F {
   const traced = function (this: unknown, ...args: unknown[]): unknown {
     const tracer = getTracer();
-
-    if (!tracer) {
-      console.error('Tracer was not initalized yet for', options.name);
-    } else {
-      console.log('Tracer exists for', options.name);
-    }
-
     if (!tracer) return fn.apply(this, args);
 
     const shouldTrace =


### PR DESCRIPTION
Fixes #611

By removing the `trace` import, we make the `@opentelemetry/api` fully optional, avoiding errors at build time, when the package does not exist.

Since we have no way of importing the package dynamically, we have to expose the `setTracerProvider` function that consumers of the library can use to set the `trace` themselves whenever they init it.

The `@opentelemetry/api` will continue to be a `peerDependency` that's marked as optional since we make use if its types for the `setTracer` function.

I made this a `minor` as opposed to a `major`, considering we change the API, and it fixes tracing, as it's currently broken, depending on how you see it.
