### PR TITLE
cancel body instead of consuming

### DIFF
--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -219,7 +219,7 @@ async function getLocalEdgeConfig(
  * See https://developers.cloudflare.com/workers/platform/limits/#simultaneous-open-connections
  */
 async function consumeResponseBody(res: Response): Promise<void> {
-  await res.arrayBuffer();
+  await res.body?.cancel();
 }
 
 interface EdgeConfigClientOptions {


### PR DESCRIPTION
Not adding a changeset as this is not worthy of a release.

Calls cancel instead of consuming a body to reduce time spent waiting for the body when it's unused.