### PR TITLE
chore: allow supabase connection pooler uri.

### DIFF
--- a/packages/postgres/src/postgres-connection-string.ts
+++ b/packages/postgres/src/postgres-connection-string.ts
@@ -31,7 +31,7 @@ export function postgresConnectionString(
 }
 
 export function isPooledConnectionString(connectionString: string): boolean {
-  return connectionString.includes('-pooler.');
+  return connectionString.includes('pooler.');
 }
 
 export function isDirectConnectionString(connectionString: string): boolean {


### PR DESCRIPTION
Currently folks have to use modify their supabase connection string to make it work with drizzle in vercel edge functions, e.g. see https://github.com/supabase-community/create-t3-turbo/blob/main/.env.example#L8

By changing this check, the supabase connection pooler URI passes by default.