### PR TITLE
Expose types object from neon/serverless

### DIFF
--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -5,6 +5,7 @@ import type { Primitive } from './sql-template';
 export * from './create-client';
 export * from './create-pool';
 export * from './types';
+export { types } from '@neondatabase/serverless';
 export { postgresConnectionString } from './postgres-connection-string';
 
 let pool: VercelPool | undefined;


### PR DESCRIPTION
We need the `types` from the `@neondatabase/serverless` package to be exported. They are exported by `node-postgres` and also by `@neondatabase/serverless`: [here](https://github.com/neondatabase/serverless/blob/main/export/index.ts#L262)

These types are utilized by the Drizzle ORM to enable mappings for timestamps, dates, and intervals to be retrieved raw from the database, allowing Drizzle to convert them either to dates or leave them as strings: https://orm.drizzle.team/docs/column-types/pg#timestamp

<img width="869" alt="image" src="https://github.com/vercel/storage/assets/29543764/040c61f2-4a5c-4453-a920-97ca97f4c650">

Here are the places where we use them for the `node-postgres` and `@neondatabase/serverless` packages:
- [node-postgres](https://github.com/drizzle-team/drizzle-orm/blob/main/drizzle-orm/src/node-postgres/driver.ts#L41)
- [@neondatabase/serverless](https://github.com/drizzle-team/drizzle-orm/blob/main/drizzle-orm/src/neon-serverless/driver.ts#L39)

We need to have a possibility to use it with `@vercel/postgres` as well
Ideally, those interceptors should be available on a per-query basis. However, we would need to sync with the `node-postgres` maintainer first. For now, it should be fine to use them as we are currently doing and just need to mention that in docs clearly