### PR TITLE
Use a keep-alive agent for @vercel/kv by default

### DIFF
--- a/packages/kv/src/index.ts
+++ b/packages/kv/src/index.ts
@@ -1,4 +1,5 @@
-import type { Agent } from 'node:https';
+// eslint-disable-next-line unicorn/prefer-node-protocol -- Webpack doesn't like node: protocol
+import type { Agent } from 'https';
 import { Redis } from '@upstash/redis';
 import type { ScanCommandOptions, RedisConfigNodejs } from '@upstash/redis';
 
@@ -82,8 +83,8 @@ function getAgent(): Agent | undefined {
     return undefined;
   }
   const AgentClass: typeof Agent =
-    // eslint-disable-next-line @typescript-eslint/consistent-type-imports, @typescript-eslint/no-var-requires -- Legacy Node.js import.
-    (require('node:https') as typeof import('node:https')).Agent;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports, @typescript-eslint/no-var-requires, unicorn/prefer-node-protocol -- Legacy Node.js import.
+    (require('https') as typeof import('https')).Agent;
   return new AgentClass({ keepAlive: true });
 }
 


### PR DESCRIPTION
See https://upstash.com/docs/oss/sdks/ts/redis/advanced#keepalive

This has yielding substantial benefits while testing on v0

I asked why Upstash doesn't have this on-by-default
https://vercel.slack.com/archives/C02Q9BA1F8C/p1712002622991319 even though their blog says they do
https://upstash.com/blog/keepalive-in-serverless