### PR TITLE
Remove dependency pins in @vercel/blob's package.json

### DIFF
--- a/.changeset/dirty-jars-burn.md
+++ b/.changeset/dirty-jars-burn.md
@@ -1,0 +1,5 @@
+---
+"@vercel/blob": patch
+---
+
+Remove dependency pins in package.json.

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -60,10 +60,10 @@
     }
   },
   "dependencies": {
-    "async-retry": "1.3.3",
-    "bytes": "3.1.2",
-    "is-buffer": "2.0.5",
-    "undici": "5.28.3"
+    "async-retry": "^1.3.3",
+    "bytes": "^3.1.2",
+    "is-buffer": "^2.0.5",
+    "undici": "^5.28.4"
   },
   "devDependencies": {
     "@edge-runtime/jest-environment": "2.3.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,17 +48,17 @@ importers:
   packages/blob:
     dependencies:
       async-retry:
-        specifier: 1.3.3
+        specifier: ^1.3.3
         version: 1.3.3
       bytes:
-        specifier: 3.1.2
+        specifier: ^3.1.2
         version: 3.1.2
       is-buffer:
-        specifier: 2.0.5
+        specifier: ^2.0.5
         version: 2.0.5
       undici:
-        specifier: 5.28.3
-        version: 5.28.3
+        specifier: ^5.28.4
+        version: 5.28.4
     devDependencies:
       '@edge-runtime/jest-environment':
         specifier: 2.3.10
@@ -7902,8 +7902,8 @@ packages:
       '@fastify/busboy': 2.1.0
     dev: false
 
-  /undici@5.28.3:
-    resolution: {integrity: sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==}
+  /undici@5.28.4:
+    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.1.0


### PR DESCRIPTION
There's currently a [low-severity vulnerability in undici](https://github.com/advisories/GHSA-9qxr-qj54-h672) and this package's dependencies are making it harder for me to update to a patched version. Any objection to unpinning the dependencies?