### PR TITLE
Handle promise rejection

### DIFF
--- a/.changeset/chilled-spies-train.md
+++ b/.changeset/chilled-spies-train.md
@@ -1,0 +1,5 @@
+---
+"@vercel/edge-config": patch
+---
+
+Resolved bug where an unhandled promise rejection event may have been triggered during development

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -136,48 +136,55 @@ function createGetInMemoryEdgeConfig(
   let latestRequest: Promise<EmbeddedEdgeConfig | null> | null = null;
 
   return trace(
-    async () => {
-      if (!shouldUseDevelopmentCache) return null;
+    () => {
+      if (!shouldUseDevelopmentCache) return Promise.resolve(null);
 
-      latestRequest ??= fetchWithCachedResponse(
-        `${connection.baseUrl}/items?version=${connection.version}`,
-        {
-          headers: new Headers(headers),
-          cache: 'no-store',
-        },
-      ).then(async (res) => {
-        const digest = res.headers.get('x-edge-config-digest');
-        let body: EdgeConfigValue | undefined;
+      if (!latestRequest) {
+        latestRequest = fetchWithCachedResponse(
+          `${connection.baseUrl}/items?version=${connection.version}`,
+          {
+            headers: new Headers(headers),
+            cache: 'no-store',
+          },
+        ).then(async (res) => {
+          const digest = res.headers.get('x-edge-config-digest');
+          let body: EdgeConfigValue | undefined;
 
-        // We ignore all errors here and just proceed.
-        if (!res.ok) {
-          await consumeResponseBody(res);
-          body = res.cachedResponseBody as EdgeConfigValue | undefined;
-          if (!body) return null;
-        } else {
-          body = (await res.json()) as EdgeConfigItems;
-        }
+          // We ignore all errors here and just proceed.
+          if (!res.ok) {
+            await consumeResponseBody(res);
+            body = res.cachedResponseBody as EdgeConfigValue | undefined;
+            if (!body) return null;
+          } else {
+            body = (await res.json()) as EdgeConfigItems;
+          }
 
-        return { digest, items: body } as EmbeddedEdgeConfig;
-      });
-
-      // Ensures that the last request will overwrite the `embeddedEdgeConfigPromise`
-      // and clean up the `lastRequest` cache to make sure the next call
-      // will trigger a new request.
-      void latestRequest
-        .then((resolved) => {
-          embeddedEdgeConfigPromise = Promise.resolve(resolved);
-        })
-        .finally(() => {
-          latestRequest = null;
+          return { digest, items: body } as EmbeddedEdgeConfig;
         });
 
-      embeddedEdgeConfigPromise ??= latestRequest;
+        // Once the request is resolved, we se the proper config to the promise
+        // such that the next call will return the resolved value.
+        latestRequest.then(
+          (resolved) => {
+            embeddedEdgeConfigPromise = Promise.resolve(resolved);
+            latestRequest = null;
+          },
+          // Attach a `.catch` handler to this promise so that if it does throw,
+          // we don't get an unhandled promise rejection event. We unset the
+          // `latestRequest` so that the next call will make a new request.
+          () => {
+            embeddedEdgeConfigPromise = null;
+            latestRequest = null;
+          },
+        );
+      }
 
-      // Ensure we don't keep a rejected promise in memory
-      embeddedEdgeConfigPromise.catch(() => {
-        embeddedEdgeConfigPromise = null;
-      });
+      if (!embeddedEdgeConfigPromise) {
+        // If the `embeddedEdgeConfigPromise` is `null`, it means that there's
+        // no previous request, so we'll set the `latestRequest` to the current
+        // request.
+        embeddedEdgeConfigPromise = latestRequest;
+      }
 
       return embeddedEdgeConfigPromise;
     },

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -162,7 +162,7 @@ function createGetInMemoryEdgeConfig(
           return { digest, items: body } as EmbeddedEdgeConfig;
         });
 
-        // Once the request is resolved, we se the proper config to the promise
+        // Once the request is resolved, we set the proper config to the promise
         // such that the next call will return the resolved value.
         latestRequest.then(
           (resolved) => {


### PR DESCRIPTION
This handles the promise rejection when the `latestRequest` rejects. It's important to add where we used to have the `void` as invoking the `.then` will wait another microtick as well as re-throw any error that occurred during the initial promise. The promise is returned later, and ensures that the promise can be await'ed and/or handled.

Note, you may need to turn off hide whitespace to see the changes, I swapped out the `??=` to make it more explicit as to when the initialization of the promises occurred.