### PR TITLE
fix(blob): better typing for `put()`

### DIFF
--- a/packages/blob/src/put.ts
+++ b/packages/blob/src/put.ts
@@ -27,7 +27,7 @@ export function createPutMethod<TOptions extends PutCommandOptions>({
   return async function put<TPath extends string>(
     pathname: TPath,
     bodyOrOptions: TPath extends `${string}/` ? TOptions : PutBody,
-    optionsInput?: TPath extends `${string}/` ? never : TOptions,
+    ...optionsInput: TPath extends `${string}/` ? [] : [TOptions]
   ): Promise<PutBlobResult> {
     const isFolderCreation = pathname.endsWith('/');
 
@@ -36,7 +36,7 @@ export function createPutMethod<TOptions extends PutCommandOptions>({
       throw new BlobError('body is required');
     }
 
-    // runtime check for non TS users that provide all three args
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime check for non TS users that provide all three args
     if (bodyOrOptions && optionsInput && isFolderCreation) {
       throw new BlobError('body is not allowed for creating empty folders');
     }
@@ -47,7 +47,9 @@ export function createPutMethod<TOptions extends PutCommandOptions>({
     const options = await createPutOptions({
       pathname,
       // when no body is required (for folder creations) options are the second argument
-      options: isFolderCreation ? (bodyOrOptions as TOptions) : optionsInput,
+      options: isFolderCreation
+        ? (bodyOrOptions as TOptions)
+        : (optionsInput as unknown as TOptions),
       extraChecks,
       getToken,
     });


### PR DESCRIPTION
Ensure to raise a type error when a file is created (not a folder) and the options are missing.

I just got started with Vercel Blob and ended up having a "missing options, see usage" BlobError that required me to take a look at the typing to understand that a 3rd argument was missing ([as stated in the docs](https://vercel.com/docs/storage/vercel-blob/using-blob-sdk#put)).

This is an attempt to strengthen the typing, some type predicates could be used to better narrow down the `optionsInput` inside the function's body.