### PR TITLE
allow setting fetch cache behavior, remove DeepReadOnly

### DIFF
--- a/.changeset/dull-pets-try.md
+++ b/.changeset/dull-pets-try.md
@@ -1,0 +1,5 @@
+---
+"@vercel/edge-config": major
+---
+
+remove DeepReadOnly type

--- a/.changeset/dull-pets-try.md
+++ b/.changeset/dull-pets-try.md
@@ -1,5 +1,5 @@
 ---
-"@vercel/edge-config": major
+"@vercel/edge-config": patch
 ---
 
 remove DeepReadOnly type

--- a/.changeset/thick-shirts-chew.md
+++ b/.changeset/thick-shirts-chew.md
@@ -1,0 +1,5 @@
+---
+"@vercel/edge-config": minor
+---
+
+allow setting fetch cache behaviour

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -151,15 +151,17 @@ edgeConfigClient.get('someKey');
 
 **Note** This opts out of dynamic behavior, so the page might display stale values.
 
-## Caught a Bug?
+## Notes
 
-1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device
-2. Link the package to the global module directory: `npm link`
-3. Within the module you want to test your local development instance of `@vercel/edge-config`, just link it to the dependencies: `npm link @vercel/edge-config`. Instead of the default one from npm, Node.js will now use your clone of `@vercel/edge-config`!
+### Do not mutate return values
 
-As always, you can run the tests using: `npm test`
+Cloning objects in JavaScript can be slow. That's why the Edge Config SDK uses an optimization which can lead to multiple calls reading the same key all receiving a reference to the same value.
 
-## A note for Vite users
+For this reason the value read from Edge Config should never be mutated, otherwise they could affect other parts of the code base reading the same key, or a later request reading the same key.
+
+If you need to modify, see the `clone` function described [here](#do-not-mutate-return-values).
+
+### Usage with Vite
 
 `@vercel/edge-config` reads database credentials from the environment variables on `process.env`. In general, `process.env` is automatically populated from your `.env` file during development, which is created when you run `vc env pull`. However, Vite does not expose the `.env` variables on `process.env.`
 
@@ -199,3 +201,11 @@ import { createClient } from '@vercel/edge-config';
 + const edgeConfig = createClient(EDGE_CONFIG);
 await edgeConfig.get('someKey');
 ```
+
+## Caught a Bug?
+
+1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device
+2. Link the package to the global module directory: `npm link`
+3. Within the module you want to test your local development instance of `@vercel/edge-config`, just link it to the dependencies: `npm link @vercel/edge-config`. Instead of the default one from npm, Node.js will now use your clone of `@vercel/edge-config`!
+
+As always, you can run the tests using: `npm test`

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -132,6 +132,25 @@ setTracerProvider(trace);
 
 More verbose traces can be enabled by setting the `EDGE_CONFIG_TRACE_VERBOSE` environment variable to `true`.
 
+## Fetch cache
+
+By default the Edge Config SDK will fetch with `no-store`, which triggers dynamic mode in Next.js ([docs](https://nextjs.org/docs/app/api-reference/functions/fetch#optionscache)).
+
+To use Edge Config with static pages, pass the `force-cache` option:
+
+```js
+import { createClient } from '@vercel/edge-config';
+
+const edgeConfigClient = createClient(process.env.EDGE_CONFIG, {
+  cache: 'force-cache',
+});
+
+// then use the client as usual
+edgeConfigClient.get('someKey');
+```
+
+**Note** This opts out of dynamic behavior, so the page might display stale values.
+
 ## Caught a Bug?
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device

--- a/packages/edge-config/package.json
+++ b/packages/edge-config/package.json
@@ -41,8 +41,7 @@
     "testEnvironment": "node"
   },
   "dependencies": {
-    "@vercel/edge-config-fs": "workspace:*",
-    "ts-essentials": "9.4.1"
+    "@vercel/edge-config-fs": "workspace:*"
   },
   "devDependencies": {
     "@changesets/cli": "2.27.1",

--- a/packages/edge-config/src/types.ts
+++ b/packages/edge-config/src/types.ts
@@ -1,5 +1,3 @@
-import type { DeepReadonly } from 'ts-essentials';
-
 export interface EmbeddedEdgeConfig {
   digest: string;
   items: Record<string, EdgeConfigValue>;
@@ -40,9 +38,7 @@ export interface EdgeConfigClient {
    * @param key - the key to read
    * @returns the value stored under the given key, or undefined
    */
-  get: <T = EdgeConfigValue>(
-    key: string,
-  ) => Promise<DeepReadonly<T> | undefined>;
+  get: <T = EdgeConfigValue>(key: string) => Promise<T | undefined>;
   /**
    * Reads multiple or all values.
    *
@@ -51,7 +47,7 @@ export interface EdgeConfigClient {
    * @param keys - the keys to read
    * @returns Returns all entries when called with no arguments or only entries matching the given keys otherwise.
    */
-  getAll: <T = EdgeConfigItems>(keys?: (keyof T)[]) => Promise<DeepReadonly<T>>;
+  getAll: <T = EdgeConfigItems>(keys?: (keyof T)[]) => Promise<T>;
   /**
    * Check if a given key exists in the Edge Config.
    *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,9 +108,6 @@ importers:
       '@vercel/edge-config-fs':
         specifier: workspace:*
         version: link:../edge-config-fs
-      ts-essentials:
-        specifier: 9.4.1
-        version: 9.4.1(typescript@5.3.3)
     devDependencies:
       '@changesets/cli':
         specifier: 2.27.1
@@ -7756,17 +7753,6 @@ packages:
       typescript: '>=4.2.0'
     dependencies:
       typescript: 5.3.3
-
-  /ts-essentials@9.4.1(typescript@5.3.3):
-    resolution: {integrity: sha512-oke0rI2EN9pzHsesdmrOrnqv1eQODmJpd/noJjwj2ZPC3Z4N2wbjrOEqnsEgmvlO2+4fBb0a794DCna2elEVIQ==}
-    peerDependencies:
-      typescript: '>=4.1.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      typescript: 5.3.3
-    dev: false
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}


### PR DESCRIPTION
- Removes the DeepReadonly type
- Allows configuring `cache` option on fetch request when creating an edge config client
  - see https://nextjs.org/docs/app/api-reference/functions/fetch#optionscache

We received feedback that working with the `DeepReadonly` type is problematic. We removed this from the types. Return types of functions reading edge config values are no longer marked as readonly. 