### PR TITLE
fix(blob): Throw when trying to upload a plain JS object

### DIFF
--- a/.changeset/tiny-ants-behave.md
+++ b/.changeset/tiny-ants-behave.md
@@ -1,0 +1,5 @@
+---
+"@vercel/blob": patch
+---
+
+fix(blob): Throw when trying to upload a plain JS object

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -63,6 +63,7 @@
     "async-retry": "^1.3.3",
     "bytes": "^3.1.2",
     "is-buffer": "^2.0.5",
+    "is-plain-object": "^5.0.0",
     "undici": "^5.28.4"
   },
   "devDependencies": {

--- a/packages/blob/src/index.browser.test.ts
+++ b/packages/blob/src/index.browser.test.ts
@@ -1,5 +1,7 @@
 import { put } from './index';
 
+// This files ensures some of the Node.js methods can also be called when imported in a browser
+
 const BLOB_STORE_BASE_URL = 'https://storeId.public.blob.vercel-storage.com';
 
 // Can't use the usual undici mocking utilities because they don't work with jsdom environment

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -576,6 +576,18 @@ describe('blob client', () => {
       expect(headers['x-cache-control-max-age']).toEqual('60');
     });
 
+    // Some folks are trying to upload plain objects which cannot work, example: https://github.com/vercel/storage/issues/637
+    it('throws when trying to upload a plain JS object', async () => {
+      await expect(() =>
+        // @ts-expect-error: Runtime check fo DX
+        put('foo.txt', { file: 'value' }, { access: 'public' }),
+      ).rejects.toThrow(
+        new Error(
+          "Vercel Blob: Body must be a string, buffer or stream. You sent a plain JavaScript object, double check what you're trying to upload.",
+        ),
+      );
+    });
+
     const table: [string, (signal: AbortSignal) => Promise<unknown>][] = [
       [
         'put',

--- a/packages/blob/src/multipart/create-uploader.ts
+++ b/packages/blob/src/multipart/create-uploader.ts
@@ -1,10 +1,11 @@
-import type { CommonCreateBlobOptions } from '../helpers';
+import { isPlainObject } from 'is-plain-object';
+import { BlobError, type CommonCreateBlobOptions } from '../helpers';
 import type { CreatePutMethodOptions, PutBody } from '../put-helpers';
 import { createPutHeaders, createPutOptions } from '../put-helpers';
 import { completeMultipartUpload } from './complete';
 import { createMultipartUpload } from './create';
 import type { Part } from './helpers';
-import { uploadPart } from './upload';
+import { uploadPart as rawUploadPart } from './upload';
 
 export function createCreateMultipartUploaderMethod<
   TOptions extends CommonCreateBlobOptions,
@@ -30,7 +31,13 @@ export function createCreateMultipartUploaderMethod<
       uploadId: createMultipartUploadResponse.uploadId,
 
       async uploadPart(partNumber: number, body: PutBody) {
-        const result = await uploadPart({
+        if (isPlainObject(body)) {
+          throw new BlobError(
+            "Body must be a string, buffer or stream. You sent a plain JavaScript object, double check what you're trying to upload.",
+          );
+        }
+
+        const result = await rawUploadPart({
           uploadId: createMultipartUploadResponse.uploadId,
           key: createMultipartUploadResponse.key,
           pathname,

--- a/packages/blob/src/multipart/upload.ts
+++ b/packages/blob/src/multipart/upload.ts
@@ -1,8 +1,13 @@
 import bytes from 'bytes';
 import type { BodyInit } from 'undici';
+import { isPlainObject } from 'is-plain-object';
 import { BlobServiceNotAvailable, requestApi } from '../api';
 import { debug } from '../debug';
-import type { CommonCreateBlobOptions, BlobCommandOptions } from '../helpers';
+import {
+  type CommonCreateBlobOptions,
+  type BlobCommandOptions,
+  BlobError,
+} from '../helpers';
 import { createPutHeaders, createPutOptions } from '../put-helpers';
 import type { PutBody, CreatePutMethodOptions } from '../put-helpers';
 import type { Part, PartInput } from './helpers';
@@ -33,6 +38,12 @@ export function createUploadPartMethod<
     });
 
     const headers = createPutHeaders(allowedOptions, options);
+
+    if (isPlainObject(body)) {
+      throw new BlobError(
+        "Body must be a string, buffer or stream. You sent a plain JavaScript object, double check what you're trying to upload.",
+      );
+    }
 
     const result = await uploadPart({
       uploadId: options.uploadId,

--- a/packages/blob/src/put.ts
+++ b/packages/blob/src/put.ts
@@ -1,4 +1,5 @@
 import type { BodyInit } from 'undici';
+import { isPlainObject } from 'is-plain-object';
 import { requestApi } from './api';
 import type { CommonCreateBlobOptions } from './helpers';
 import { BlobError } from './helpers';
@@ -53,6 +54,12 @@ export function createPutMethod<TOptions extends PutCommandOptions>({
     });
 
     const headers = createPutHeaders(allowedOptions, options);
+
+    if (body !== undefined && isPlainObject(body)) {
+      throw new BlobError(
+        "Body must be a string, buffer or stream. You sent a plain JavaScript object, double check what you're trying to upload.",
+      );
+    }
 
     if (options.multipart === true && body) {
       return uncontrolledMultipartUpload(pathname, body, headers, options);

--- a/packages/blob/src/put.ts
+++ b/packages/blob/src/put.ts
@@ -45,6 +45,12 @@ export function createPutMethod<TOptions extends PutCommandOptions>({
     // avoid using the options as body
     const body = isFolderCreation ? undefined : bodyOrOptions;
 
+    if (body !== undefined && isPlainObject(body)) {
+      throw new BlobError(
+        "Body must be a string, buffer or stream. You sent a plain JavaScript object, double check what you're trying to upload.",
+      );
+    }
+
     const options = await createPutOptions({
       pathname,
       // when no body is required (for folder creations) options are the second argument
@@ -54,12 +60,6 @@ export function createPutMethod<TOptions extends PutCommandOptions>({
     });
 
     const headers = createPutHeaders(allowedOptions, options);
-
-    if (body !== undefined && isPlainObject(body)) {
-      throw new BlobError(
-        "Body must be a string, buffer or stream. You sent a plain JavaScript object, double check what you're trying to upload.",
-      );
-    }
 
     if (options.multipart === true && body) {
       return uncontrolledMultipartUpload(pathname, body, headers, options);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       is-buffer:
         specifier: ^2.0.5
         version: 2.0.5
+      is-plain-object:
+        specifier: ^5.0.0
+        version: 5.0.0
       undici:
         specifier: ^5.28.4
         version: 5.28.4
@@ -5230,6 +5233,11 @@ packages:
   /is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  /is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}


### PR DESCRIPTION
Before this commit, customers had sometimes trouble trying to upload a file. For example when using `multer`, the req.file is not the file but a plain JS object with file details. To upload it you would need to do req.file.buffer.

Fixes #637