### PR TITLE
protect against empty key reads

### DIFF
--- a/.changeset/witty-rings-compare.md
+++ b/.changeset/witty-rings-compare.md
@@ -1,0 +1,9 @@
+---
+"@vercel/edge-config": patch
+---
+
+gracefully handle when an empty string is supplied as the key
+
+- `get("")` will return `undefined`
+- `has("")` will return `false`
+- `getAll(["a", ""])` will ignore the empty string

--- a/packages/edge-config/src/index.common.test.ts
+++ b/packages/edge-config/src/index.common.test.ts
@@ -124,6 +124,12 @@ describe('when running without lambda layer or via edge function', () => {
         );
       });
     });
+    describe('attempting to read an empty key', () => {
+      it('should return undefined', async () => {
+        await expect(edgeConfig.get('')).resolves.toBe(undefined);
+        expect(fetchMock).toHaveBeenCalledTimes(0);
+      });
+    });
   });
 
   describe('has(key)', () => {
@@ -147,6 +153,12 @@ describe('when running without lambda layer or via edge function', () => {
             cache: 'no-store',
           },
         );
+      });
+    });
+    describe('attempting to read an empty key', () => {
+      it('should return false', async () => {
+        await expect(edgeConfig.has('')).resolves.toBe(false);
+        expect(fetchMock).toHaveBeenCalledTimes(0);
       });
     });
   });

--- a/packages/edge-config/src/utils/index.ts
+++ b/packages/edge-config/src/utils/index.ts
@@ -38,6 +38,10 @@ export function assertIsKey(key: unknown): asserts key is string {
   }
 }
 
+export function isEmptyKey(key: string): boolean {
+  return key.trim() === '';
+}
+
 export function assertIsKeys(keys: unknown): asserts keys is string[] {
   if (!Array.isArray(keys) || keys.some((key) => typeof key !== 'string')) {
     throw new Error(


### PR DESCRIPTION
Previously trying to call `get("")` with an empty string would throw an `Edge Config not found` error

Now
- `get("")` returns `undefined`
- `has("")` returns `false`