### PR TITLE
[edge-config] Support new connection string format

### DIFF
--- a/.changeset/lovely-coins-relax.md
+++ b/.changeset/lovely-coins-relax.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': minor
+---
+
+Support new connection string format

--- a/packages/edge-config/src/index.common.test.ts
+++ b/packages/edge-config/src/index.common.test.ts
@@ -76,6 +76,38 @@ describe('parseConnectionString', () => {
       version: '1',
     });
   });
+
+  it('should return a valid connection for an `edgd-config:` connection string', () => {
+    expect(
+      pkg.parseConnectionString(
+        'edge-config:id=ecfg_cljia81u2q1gappdgptj881dwwtc&token=00000000-0000-0000-0000-000000000000',
+      ),
+    ).toEqual({
+      baseUrl:
+        'https://edge-config.vercel.com/ecfg_cljia81u2q1gappdgptj881dwwtc',
+      id: 'ecfg_cljia81u2q1gappdgptj881dwwtc',
+      token: '00000000-0000-0000-0000-000000000000',
+      type: 'vercel',
+      version: '1',
+    });
+  });
+
+  it('should return null for an invalid `edge-config:` connection string', () => {
+    expect(pkg.parseConnectionString('edge-config:token=abd&id=')).toEqual(
+      null,
+    );
+    expect(
+      pkg.parseConnectionString(
+        'edge-config:ecfg_cljia81u2q1gappdgptj881dwwtc',
+      ),
+    ).toEqual(null);
+    expect(
+      pkg.parseConnectionString(
+        'edge-config:id=ecfg_cljia81u2q1gappdgptj881dwwtc',
+      ),
+    ).toEqual(null);
+    expect(pkg.parseConnectionString('edge-config:invalid')).toEqual(null);
+  });
 });
 
 describe('when running without lambda layer or via edge function', () => {


### PR DESCRIPTION
Updates the Edge Config SDK to support a new format for Edge Config connection strings.

We previously used an URL like the following:
```
https://edge-config.vercel.com/<id>?token=<token>
```

For simplicity and avoiding security concerns about sharing an URL with the token in it, we'll add support for the following format:
```
edge-config:id=<id>&token=<token>
```
