### PR TITLE
fix(blob): limit keys to 950 characters

### DIFF
--- a/.changeset/unlucky-months-repeat.md
+++ b/.changeset/unlucky-months-repeat.md
@@ -1,0 +1,5 @@
+---
+'@vercel/blob': patch
+---
+
+Limit pathname length to 950 to respect internal limitations and provide better early DX.

--- a/packages/blob/src/api.ts
+++ b/packages/blob/src/api.ts
@@ -5,6 +5,12 @@ import { debug } from './debug';
 import type { BlobCommandOptions } from './helpers';
 import { BlobError, getTokenFromOptionsOrEnv } from './helpers';
 
+// maximum pathname length is:
+// 1024 (provider limit) - 26 chars (vercel  internal suffixes) - 31 chars (blob `-randomId` suffix) = 967
+// we round it to 950 to make it more human friendly, and we apply the limit whatever the value of
+// addRandomSuffix is, to make it consistent
+export const MAXIMUM_PATHNAME_LENGTH = 950;
+
 export class BlobAccessError extends BlobError {
   constructor() {
     super('Access denied, please provide a valid token for this resource.');

--- a/packages/blob/src/copy.ts
+++ b/packages/blob/src/copy.ts
@@ -1,4 +1,4 @@
-import { requestApi } from './api';
+import { MAXIMUM_PATHNAME_LENGTH, requestApi } from './api';
 import type { CommonCreateBlobOptions } from './helpers';
 import { BlobError } from './helpers';
 
@@ -33,6 +33,12 @@ export async function copy(
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Runtime check for DX.
   if (options.access !== 'public') {
     throw new BlobError('access must be "public"');
+  }
+
+  if (toPathname.length > MAXIMUM_PATHNAME_LENGTH) {
+    throw new BlobError(
+      `pathname is too long, maximum length is ${MAXIMUM_PATHNAME_LENGTH}`,
+    );
   }
 
   const headers: Record<string, string> = {};

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -577,13 +577,6 @@ describe('blob client', () => {
     });
 
     it('throws when filepath is too long', async () => {
-      mockClient
-        .intercept({
-          path: () => true,
-          method: 'PUT',
-        })
-        .reply(200, mockedFileMetaPut);
-
       await expect(
         put('a'.repeat(951), 'Test Body', {
           access: 'public',
@@ -715,6 +708,18 @@ describe('blob client', () => {
         new Error(
           "Vercel Blob: Body must be a string, buffer or stream. You sent a plain JavaScript object, double check what you're trying to upload.",
         ),
+      );
+    });
+  });
+
+  describe('copy', () => {
+    it('throws when filepath is too long', async () => {
+      await expect(
+        copy('source', 'a'.repeat(951), {
+          access: 'public',
+        }),
+      ).rejects.toThrow(
+        new Error('Vercel Blob: pathname is too long, maximum length is 950'),
       );
     });
   });

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -576,6 +576,23 @@ describe('blob client', () => {
       expect(headers['x-cache-control-max-age']).toEqual('60');
     });
 
+    it('throws when filepath is too long', async () => {
+      mockClient
+        .intercept({
+          path: () => true,
+          method: 'PUT',
+        })
+        .reply(200, mockedFileMetaPut);
+
+      await expect(
+        put('a'.repeat(951), 'Test Body', {
+          access: 'public',
+        }),
+      ).rejects.toThrow(
+        new Error('Vercel Blob: pathname is too long, maximum length is 950'),
+      );
+    });
+
     const table: [string, (signal: AbortSignal) => Promise<unknown>][] = [
       [
         'put',

--- a/packages/blob/src/put-helpers.ts
+++ b/packages/blob/src/put-helpers.ts
@@ -68,6 +68,12 @@ export function createPutHeaders<TOptions extends CommonPutCommandOptions>(
   return headers;
 }
 
+// maximum path length is:
+// 1024 (provider limit) - 26 chars (vercel  internal suffixes) - 31 chars (blob `-randomId` suffix) = 967
+// we round it to 950 to make it more human friendly, and we apply the limit whatever the value of
+// addRandomSuffix is, to make it consistent
+const MAXIMUM_PATH_LENGTH = 950;
+
 export async function createPutOptions<
   TOptions extends CommonPutCommandOptions,
 >({
@@ -83,6 +89,12 @@ export async function createPutOptions<
 }): Promise<TOptions> {
   if (!pathname) {
     throw new BlobError('pathname is required');
+  }
+
+  if (pathname.length > MAXIMUM_PATH_LENGTH) {
+    throw new BlobError(
+      `pathname is too long, maximum length is ${MAXIMUM_PATH_LENGTH}`,
+    );
   }
 
   if (!options) {

--- a/packages/blob/src/put-helpers.ts
+++ b/packages/blob/src/put-helpers.ts
@@ -3,6 +3,7 @@ import type { Readable } from 'stream';
 import type { ClientCommonCreateBlobOptions } from './client';
 import type { CommonCreateBlobOptions } from './helpers';
 import { BlobError } from './helpers';
+import { MAXIMUM_PATHNAME_LENGTH } from './api';
 
 const putOptionHeaderMap = {
   cacheControlMaxAge: 'x-cache-control-max-age',
@@ -67,12 +68,6 @@ export function createPutHeaders<TOptions extends CommonPutCommandOptions>(
 
   return headers;
 }
-
-// maximum pathname length is:
-// 1024 (provider limit) - 26 chars (vercel  internal suffixes) - 31 chars (blob `-randomId` suffix) = 967
-// we round it to 950 to make it more human friendly, and we apply the limit whatever the value of
-// addRandomSuffix is, to make it consistent
-const MAXIMUM_PATHNAME_LENGTH = 950;
 
 export async function createPutOptions<
   TOptions extends CommonPutCommandOptions,

--- a/packages/blob/src/put-helpers.ts
+++ b/packages/blob/src/put-helpers.ts
@@ -68,7 +68,7 @@ export function createPutHeaders<TOptions extends CommonPutCommandOptions>(
   return headers;
 }
 
-// maximum path length is:
+// maximum pathname length is:
 // 1024 (provider limit) - 26 chars (vercel  internal suffixes) - 31 chars (blob `-randomId` suffix) = 967
 // we round it to 950 to make it more human friendly, and we apply the limit whatever the value of
 // addRandomSuffix is, to make it consistent

--- a/packages/blob/src/put-helpers.ts
+++ b/packages/blob/src/put-helpers.ts
@@ -72,7 +72,7 @@ export function createPutHeaders<TOptions extends CommonPutCommandOptions>(
 // 1024 (provider limit) - 26 chars (vercel  internal suffixes) - 31 chars (blob `-randomId` suffix) = 967
 // we round it to 950 to make it more human friendly, and we apply the limit whatever the value of
 // addRandomSuffix is, to make it consistent
-const MAXIMUM_PATH_LENGTH = 950;
+const MAXIMUM_PATHNAME_LENGTH = 950;
 
 export async function createPutOptions<
   TOptions extends CommonPutCommandOptions,
@@ -91,9 +91,9 @@ export async function createPutOptions<
     throw new BlobError('pathname is required');
   }
 
-  if (pathname.length > MAXIMUM_PATH_LENGTH) {
+  if (pathname.length > MAXIMUM_PATHNAME_LENGTH) {
     throw new BlobError(
-      `pathname is too long, maximum length is ${MAXIMUM_PATH_LENGTH}`,
+      `pathname is too long, maximum length is ${MAXIMUM_PATHNAME_LENGTH}`,
     );
   }
 


### PR DESCRIPTION
To respect internal limitations we have, let's limit keys to 950 charactersa and
warn when you use more than that.
