### PR TITLE
chore(kv): update kv package json with new upstash version

### DIFF
--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -43,7 +43,7 @@
     "testEnvironment": "node"
   },
   "dependencies": {
-    "@upstash/redis": "^1.31.3"
+    "@upstash/redis": "^1.34.0"
   },
   "devDependencies": {
     "@changesets/cli": "2.27.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,7 +163,7 @@ importers:
   packages/kv:
     dependencies:
       '@upstash/redis':
-        specifier: ^1.31.3
+        specifier: ^1.34.0
         version: 1.34.0
     devDependencies:
       '@changesets/cli':


### PR DESCRIPTION
I forgot to update package.json in https://github.com/vercel/storage/pull/713.