### PR TITLE
chore: fix deprecation warning from husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "turbo build",
     "integration-test": "turbo integration-test",
     "lint": "turbo lint -- --max-warnings=0",
-    "prepare": "husky install",
+    "prepare": "husky",
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write .",
     "publint": "turbo publint",


### PR DESCRIPTION
Fixes deprecation warnings when you commit changes.

See "How to migrate" https://github.com/typicode/husky/releases/tag/v9.0.1