### PR TITLE
fix(blob): Allow for Request object to be a body of objects

### DIFF
--- a/.changeset/pretty-tomatoes-jump.md
+++ b/.changeset/pretty-tomatoes-jump.md
@@ -1,0 +1,5 @@
+---
+'@vercel/blob': patch
+---
+
+Fix bad detection of Request being a plain object

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -63,7 +63,6 @@
     "async-retry": "^1.3.3",
     "bytes": "^3.1.2",
     "is-buffer": "^2.0.5",
-    "is-plain-object": "^5.0.0",
     "undici": "^5.28.4"
   },
   "devDependencies": {

--- a/packages/blob/src/helpers.ts
+++ b/packages/blob/src/helpers.ts
@@ -63,3 +63,21 @@ export function getDownloadUrl(blobUrl: string): string {
 
   return url.toString();
 }
+
+// Extracted from https://github.com/sindresorhus/is-plain-obj/blob/main/index.js
+// It's just nearly impossible to use ESM modules with our current setup
+export function isPlainObject(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- ok
+  const prototype = Object.getPrototypeOf(value);
+  return (
+    (prototype === null ||
+      prototype === Object.prototype ||
+      Object.getPrototypeOf(prototype) === null) &&
+    !(Symbol.toStringTag in value) &&
+    !(Symbol.iterator in value)
+  );
+}

--- a/packages/blob/src/multipart/create-uploader.ts
+++ b/packages/blob/src/multipart/create-uploader.ts
@@ -1,5 +1,8 @@
-import { isPlainObject } from 'is-plain-object';
-import { BlobError, type CommonCreateBlobOptions } from '../helpers';
+import {
+  BlobError,
+  isPlainObject,
+  type CommonCreateBlobOptions,
+} from '../helpers';
 import type { CreatePutMethodOptions, PutBody } from '../put-helpers';
 import { createPutHeaders, createPutOptions } from '../put-helpers';
 import { completeMultipartUpload } from './complete';

--- a/packages/blob/src/multipart/upload.ts
+++ b/packages/blob/src/multipart/upload.ts
@@ -1,12 +1,12 @@
 import bytes from 'bytes';
 import type { BodyInit } from 'undici';
-import { isPlainObject } from 'is-plain-object';
 import { BlobServiceNotAvailable, requestApi } from '../api';
 import { debug } from '../debug';
 import {
   type CommonCreateBlobOptions,
   type BlobCommandOptions,
   BlobError,
+  isPlainObject,
 } from '../helpers';
 import { createPutHeaders, createPutOptions } from '../put-helpers';
 import type { PutBody, CreatePutMethodOptions } from '../put-helpers';

--- a/packages/blob/src/put.ts
+++ b/packages/blob/src/put.ts
@@ -1,8 +1,7 @@
 import type { BodyInit } from 'undici';
-import { isPlainObject } from 'is-plain-object';
 import { requestApi } from './api';
 import type { CommonCreateBlobOptions } from './helpers';
-import { BlobError } from './helpers';
+import { BlobError, isPlainObject } from './helpers';
 import { uncontrolledMultipartUpload } from './multipart/uncontrolled';
 import type {
   CreatePutMethodOptions,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       is-buffer:
         specifier: ^2.0.5
         version: 2.0.5
-      is-plain-object:
-        specifier: ^5.0.0
-        version: 5.0.0
       undici:
         specifier: ^5.28.4
         version: 5.28.4
@@ -5191,11 +5188,6 @@ packages:
   /is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
-
-  /is-plain-object@5.0.0:
-    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   /is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}


### PR DESCRIPTION
Before this commit, you could not pass Request objects because of a bug in the
module we used to detect plain objects. This is now fixed.
