### PR TITLE
fix(blob): error early when trying to use conflicting characters

### DIFF
--- a/.changeset/selfish-owls-thank.md
+++ b/.changeset/selfish-owls-thank.md
@@ -1,0 +1,5 @@
+---
+'@vercel/blob': minor
+---
+
+BREAKING CHANGE, we're no more accepting non-encoded versions of ?, # and // in pathnames. If you want to use such characters in your pathnames then you will need to encode them.

--- a/packages/blob/src/copy.ts
+++ b/packages/blob/src/copy.ts
@@ -1,6 +1,6 @@
 import { MAXIMUM_PATHNAME_LENGTH, requestApi } from './api';
 import type { CommonCreateBlobOptions } from './helpers';
-import { BlobError } from './helpers';
+import { BlobError, disallowedPathnameCharacters } from './helpers';
 
 export type CopyCommandOptions = CommonCreateBlobOptions;
 
@@ -39,6 +39,14 @@ export async function copy(
     throw new BlobError(
       `pathname is too long, maximum length is ${MAXIMUM_PATHNAME_LENGTH}`,
     );
+  }
+
+  for (const invalidCharacter of disallowedPathnameCharacters) {
+    if (toPathname.includes(invalidCharacter)) {
+      throw new BlobError(
+        `pathname cannot contain "${invalidCharacter}", please encode it if needed`,
+      );
+    }
   }
 
   const headers: Record<string, string> = {};

--- a/packages/blob/src/helpers.ts
+++ b/packages/blob/src/helpers.ts
@@ -81,3 +81,5 @@ export function isPlainObject(value: unknown): boolean {
     !(Symbol.iterator in value)
   );
 }
+
+export const disallowedPathnameCharacters = ['#', '?', '//'];

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -586,6 +586,42 @@ describe('blob client', () => {
       );
     });
 
+    it('throws when pathname contains #', async () => {
+      await expect(
+        put('foo#bar.txt', 'Test Body', {
+          access: 'public',
+        }),
+      ).rejects.toThrow(
+        new Error(
+          'Vercel Blob: pathname cannot contain "#", please encode it if needed',
+        ),
+      );
+    });
+
+    it('throws when pathname contains ?', async () => {
+      await expect(
+        put('foo?bar.txt', 'Test Body', {
+          access: 'public',
+        }),
+      ).rejects.toThrow(
+        new Error(
+          'Vercel Blob: pathname cannot contain "?", please encode it if needed',
+        ),
+      );
+    });
+
+    it('throws when pathname contains //', async () => {
+      await expect(
+        put('foo//bar.txt', 'Test Body', {
+          access: 'public',
+        }),
+      ).rejects.toThrow(
+        new Error(
+          'Vercel Blob: pathname cannot contain "//", please encode it if needed',
+        ),
+      );
+    });
+
     const table: [string, (signal: AbortSignal) => Promise<unknown>][] = [
       [
         'put',

--- a/packages/blob/src/put-helpers.ts
+++ b/packages/blob/src/put-helpers.ts
@@ -2,7 +2,7 @@
 import type { Readable } from 'stream';
 import type { ClientCommonCreateBlobOptions } from './client';
 import type { CommonCreateBlobOptions } from './helpers';
-import { BlobError } from './helpers';
+import { BlobError, disallowedPathnameCharacters } from './helpers';
 import { MAXIMUM_PATHNAME_LENGTH } from './api';
 
 export const putOptionHeaderMap = {
@@ -90,6 +90,14 @@ export async function createPutOptions<
     throw new BlobError(
       `pathname is too long, maximum length is ${MAXIMUM_PATHNAME_LENGTH}`,
     );
+  }
+
+  for (const invalidCharacter of disallowedPathnameCharacters) {
+    if (pathname.includes(invalidCharacter)) {
+      throw new BlobError(
+        `pathname cannot contain "${invalidCharacter}", please encode it if needed`,
+      );
+    }
   }
 
   if (!options) {


### PR DESCRIPTION
Trying to upload files containing ?, # or // will always result in a weird
behavior where the pathname you sent won't be exactly the one in the resulting
url. Rather than relying on this I propose we just error early on and advise to
either not use them or encode them.

BREAKING CHANGE: Previously working characters will now throw an error.
