### PR TITLE
Update release-snapshot.yaml

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Add SHORT_SHA env property with commit short sha
         run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
-        
+
       - name: Version Packages
         run: pnpm changeset version --snapshot ${SHORT_SHA}
         env:

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -73,13 +73,18 @@ jobs:
       - name: Add SHORT_SHA env property with commit short sha
         run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
 
+        
+      - name: Version Packages
+        run: pnpm changeset version --snapshot ${SHORT_SHA}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+
       - name: Build
         run: pnpm build
 
       - name: Create Snapshot Release
-        run: |
-          pnpm changeset version --snapshot ${SHORT_SHA}
-          pnpm changeset publish --no-git-tag --tag snapshot
+        run: pnpm changeset publish --no-git-tag --tag snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -72,7 +72,6 @@ jobs:
 
       - name: Add SHORT_SHA env property with commit short sha
         run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
-
         
       - name: Version Packages
         run: pnpm changeset version --snapshot ${SHORT_SHA}


### PR DESCRIPTION
Fixes the order of operations.

At the moment we are doing

```
pnpm build
pnpm changeset version
pnpm changeset publish
```

But since we are versioning after we are building it means the built packages can never know about their own version. This is critical in case any package has `import {version} from "../package.json"` as it would see the wrong version, and then report the wrong version.

To fix it we need to

```
pnpm changeset version
pnpm build
pnpm changeset publish
```