### PR TITLE
fix(@vercel/blob): Allow any character to be used in filenames.

### DIFF
--- a/.changeset/sour-turkeys-beg.md
+++ b/.changeset/sour-turkeys-beg.md
@@ -1,0 +1,7 @@
+---
+'@vercel/blob': patch
+---
+
+Allow all special characters to be used as pathname.
+You can now use all the characters you want in pathname even the ones that have
+special meaning in urls like `%!'()@{}[]#` and it will work as expected.

--- a/packages/blob/src/api.node.test.ts
+++ b/packages/blob/src/api.node.test.ts
@@ -66,7 +66,7 @@ describe('api', () => {
             authorization: 'Bearer 123',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': expect.any(String) as string,
-            'x-api-version': '8',
+            'x-api-version': '9',
           },
           method: 'POST',
         },

--- a/packages/blob/src/api.ts
+++ b/packages/blob/src/api.ts
@@ -126,7 +126,7 @@ export interface BlobApiError {
 // This version is used to ensure that the client and server are compatible
 // The server (Vercel Blob API) uses this information to change its behavior like the
 // response format
-const BLOB_API_VERSION = 8;
+const BLOB_API_VERSION = 9;
 
 function getApiVersion(): string {
   let versionOverride = null;

--- a/packages/blob/src/client.browser.test.ts
+++ b/packages/blob/src/client.browser.test.ts
@@ -85,14 +85,14 @@ describe('client', () => {
       );
       expect(fetchMock).toHaveBeenNthCalledWith(
         2,
-        'https://blob.vercel-storage.com/foo.txt',
+        'https://blob.vercel-storage.com/?pathname=foo.txt',
         {
           body: 'Test file data',
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_123',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '8',
+            'x-api-version': '9',
           },
           method: 'PUT',
         },
@@ -201,13 +201,13 @@ describe('client', () => {
 
       expect(fetchMock).toHaveBeenNthCalledWith(
         1,
-        'https://blob.vercel-storage.com/mpu/foo.txt',
+        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
         {
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '8',
+            'x-api-version': '9',
             'x-mpu-action': 'create',
           },
           method: 'POST',
@@ -217,14 +217,14 @@ describe('client', () => {
       const internalAbortSignal = new AbortController().signal;
       expect(fetchMock).toHaveBeenNthCalledWith(
         2,
-        'https://blob.vercel-storage.com/mpu/foo.txt',
+        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
         {
           body: 'data1',
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '8',
+            'x-api-version': '9',
             'x-mpu-action': 'upload',
             'x-mpu-key': 'key',
             'x-mpu-upload-id': 'uploadId',
@@ -236,14 +236,14 @@ describe('client', () => {
       );
       expect(fetchMock).toHaveBeenNthCalledWith(
         3,
-        'https://blob.vercel-storage.com/mpu/foo.txt',
+        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
         {
           body: 'data2',
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '8',
+            'x-api-version': '9',
             'x-mpu-action': 'upload',
             'x-mpu-key': 'key',
             'x-mpu-upload-id': 'uploadId',
@@ -255,7 +255,7 @@ describe('client', () => {
       );
       expect(fetchMock).toHaveBeenNthCalledWith(
         4,
-        'https://blob.vercel-storage.com/mpu/foo.txt',
+        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
         {
           body: JSON.stringify([
             { etag: 'etag1', partNumber: 1 },
@@ -266,7 +266,7 @@ describe('client', () => {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '8',
+            'x-api-version': '9',
             'x-mpu-action': 'complete',
             'x-mpu-key': 'key',
             'x-mpu-upload-id': 'uploadId',
@@ -343,13 +343,13 @@ describe('client', () => {
 
       expect(fetchMock).toHaveBeenNthCalledWith(
         1,
-        'https://blob.vercel-storage.com/mpu/foo.txt',
+        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
         {
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '8',
+            'x-api-version': '9',
             'x-mpu-action': 'create',
           },
           method: 'POST',
@@ -359,14 +359,14 @@ describe('client', () => {
       const internalAbortSignal = new AbortController().signal;
       expect(fetchMock).toHaveBeenNthCalledWith(
         2,
-        'https://blob.vercel-storage.com/mpu/foo.txt',
+        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
         {
           body: 'data1',
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '8',
+            'x-api-version': '9',
             'x-mpu-action': 'upload',
             'x-mpu-key': 'key',
             'x-mpu-upload-id': 'uploadId',
@@ -378,14 +378,14 @@ describe('client', () => {
       );
       expect(fetchMock).toHaveBeenNthCalledWith(
         3,
-        'https://blob.vercel-storage.com/mpu/foo.txt',
+        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
         {
           body: 'data2',
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '8',
+            'x-api-version': '9',
             'x-mpu-action': 'upload',
             'x-mpu-key': 'key',
             'x-mpu-upload-id': 'uploadId',
@@ -397,7 +397,7 @@ describe('client', () => {
       );
       expect(fetchMock).toHaveBeenNthCalledWith(
         4,
-        'https://blob.vercel-storage.com/mpu/foo.txt',
+        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
         {
           body: JSON.stringify([
             { etag: 'etag1', partNumber: 1 },
@@ -408,7 +408,7 @@ describe('client', () => {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '8',
+            'x-api-version': '9',
             'x-mpu-action': 'complete',
             'x-mpu-key': 'key',
             'x-mpu-upload-id': 'uploadId',

--- a/packages/blob/src/copy.ts
+++ b/packages/blob/src/copy.ts
@@ -63,8 +63,10 @@ export async function copy(
     headers['x-cache-control-max-age'] = options.cacheControlMaxAge.toString();
   }
 
+  const params = new URLSearchParams({ pathname: toPathname, fromUrl });
+
   const response = await requestApi<CopyBlobResult>(
-    `/${toPathname}?fromUrl=${fromUrl}`,
+    `?${params.toString()}`,
     {
       method: 'PUT',
       headers,

--- a/packages/blob/src/create-folder.ts
+++ b/packages/blob/src/create-folder.ts
@@ -18,14 +18,15 @@ export async function createFolder(
   pathname: string,
   options: BlobCommandOptions = {},
 ): Promise<CreateFolderResult> {
-  const path = pathname.endsWith('/') ? pathname : `${pathname}/`;
+  const folderPathname = pathname.endsWith('/') ? pathname : `${pathname}/`;
 
   const headers: Record<string, string> = {};
 
   headers[putOptionHeaderMap.addRandomSuffix] = '0';
 
+  const params = new URLSearchParams({ pathname: folderPathname });
   const response = await requestApi<PutBlobApiResponse>(
-    `/${path}`,
+    `/?${params.toString()}`,
     {
       method: 'PUT',
       headers,

--- a/packages/blob/src/helpers.ts
+++ b/packages/blob/src/helpers.ts
@@ -124,7 +124,7 @@ export function isPlainObject(value: unknown): boolean {
   );
 }
 
-export const disallowedPathnameCharacters = ['#', '?', '//'];
+export const disallowedPathnameCharacters = ['//'];
 
 // Chrome: implemented https://developer.chrome.com/docs/capabilities/web-apis/fetch-streaming-requests
 // Microsoft Edge: implemented (Chromium)
@@ -135,6 +135,13 @@ export const supportsRequestStreams = (() => {
   // TODO: Can be removed when Node.js 16 is no more required internally
   if (isNodeProcess()) {
     return true;
+  }
+
+  const apiUrl = getApiUrl();
+
+  // Localhost generally doesn't work with HTTP 2 so we can stop here
+  if (apiUrl.startsWith('http://localhost')) {
+    return false;
   }
 
   let duplexAccessed = false;
@@ -164,6 +171,7 @@ export function getApiUrl(pathname = ''): string {
   } catch {
     // noop
   }
+
   return `${baseUrl || 'https://blob.vercel-storage.com'}${pathname}`;
 }
 

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -455,7 +455,7 @@ describe('blob client', () => {
           "url": "https://storeId.public.blob.vercel-storage.com/foo-id.txt",
         }
       `);
-      expect(path).toBe('/foo.txt');
+      expect(path).toBe('/?pathname=foo.txt');
       expect(headers.authorization).toEqual('Bearer NEW_TOKEN');
       expect(body).toMatchInlineSnapshot(`"Test Body"`);
     });
@@ -612,30 +612,6 @@ describe('blob client', () => {
         }),
       ).rejects.toThrow(
         new Error('Vercel Blob: pathname is too long, maximum length is 950'),
-      );
-    });
-
-    it('throws when pathname contains #', async () => {
-      await expect(
-        put('foo#bar.txt', 'Test Body', {
-          access: 'public',
-        }),
-      ).rejects.toThrow(
-        new Error(
-          'Vercel Blob: pathname cannot contain "#", please encode it if needed',
-        ),
-      );
-    });
-
-    it('throws when pathname contains ?', async () => {
-      await expect(
-        put('foo?bar.txt', 'Test Body', {
-          access: 'public',
-        }),
-      ).rejects.toThrow(
-        new Error(
-          'Vercel Blob: pathname cannot contain "?", please encode it if needed',
-        ),
       );
     });
 

--- a/packages/blob/src/multipart/complete.ts
+++ b/packages/blob/src/multipart/complete.ts
@@ -57,9 +57,11 @@ export async function completeMultipartUpload({
   headers: Record<string, string>;
   options: BlobCommandOptions;
 }): Promise<PutBlobResult> {
+  const params = new URLSearchParams({ pathname });
+
   try {
     const response = await requestApi<PutBlobApiResponse>(
-      `/mpu/${pathname}`,
+      `/mpu?${params.toString()}`,
       {
         method: 'POST',
         headers: {
@@ -69,7 +71,7 @@ export async function completeMultipartUpload({
           'x-mpu-upload-id': uploadId,
           // key can be any utf8 character so we need to encode it as HTTP headers can only be us-ascii
           // https://www.rfc-editor.org/rfc/rfc7230#swection-3.2.4
-          'x-mpu-key': encodeURI(key),
+          'x-mpu-key': encodeURIComponent(key),
         },
         body: JSON.stringify(parts),
         signal: options.abortSignal,

--- a/packages/blob/src/multipart/create.ts
+++ b/packages/blob/src/multipart/create.ts
@@ -42,9 +42,11 @@ export async function createMultipartUpload(
 ): Promise<CreateMultipartUploadApiResponse> {
   debug('mpu: create', 'pathname:', pathname);
 
+  const params = new URLSearchParams({ pathname });
+
   try {
     const response = await requestApi<CreateMultipartUploadApiResponse>(
-      `/mpu/${pathname}`,
+      `/mpu?${params.toString()}`,
       {
         method: 'POST',
         headers: {

--- a/packages/blob/src/multipart/upload.ts
+++ b/packages/blob/src/multipart/upload.ts
@@ -77,15 +77,17 @@ export async function uploadPart({
   internalAbortController?: AbortController;
   part: PartInput;
 }): Promise<UploadPartApiResponse> {
+  const params = new URLSearchParams({ pathname });
+
   const responsePromise = requestApi<UploadPartApiResponse>(
-    `/mpu/${pathname}`,
+    `/mpu?${params.toString()}`,
     {
       signal: internalAbortController.signal,
       method: 'POST',
       headers: {
         ...headers,
         'x-mpu-action': 'upload',
-        'x-mpu-key': encodeURI(key),
+        'x-mpu-key': encodeURIComponent(key),
         'x-mpu-upload-id': uploadId,
         'x-mpu-part-number': part.partNumber.toString(),
       },

--- a/packages/blob/src/put.ts
+++ b/packages/blob/src/put.ts
@@ -58,8 +58,10 @@ export function createPutMethod<TOptions extends PutCommandOptions>({
       ? throttle(options.onUploadProgress, 100)
       : undefined;
 
+    const params = new URLSearchParams({ pathname });
+
     const response = await requestApi<PutBlobApiResponse>(
-      `/${pathname}`,
+      `/?${params.toString()}`,
       {
         method: 'PUT',
         body,

--- a/test/next/src/app/vercel/blob/script.mts
+++ b/test/next/src/app/vercel/blob/script.mts
@@ -33,7 +33,7 @@ async function run(): Promise<void> {
     createFolder(),
     manualMultipartUpload(),
     manualMultipartUploader(),
-    cancelPut(),
+    // cancelPut(),
 
     // The following stream examples will fail when targeting the local api-blob because the server doesn't buffer
     // the request body, so we have no idea of the size of the file we need to put in S3
@@ -46,7 +46,7 @@ async function run(): Promise<void> {
     fetchExampleMultipart(),
   ]);
 
-  // multipart uploads are frequently not immediately available so we have to wait a bit
+  // multipart uploads are sometimes not immediately available so we have to wait a bit
   await new Promise((resolve) => setTimeout(resolve, 5000));
 
   const filteredUrls = await Promise.all(
@@ -81,12 +81,26 @@ async function run(): Promise<void> {
 
 async function textFileExample(): Promise<string> {
   const start = Date.now();
-  const blob = await vercelBlob.put('folderé/test.txt', 'Hello, world!é', {
-    access: 'public',
-    onUploadProgress(progressEvent) {
-      console.log(progressEvent.percentage);
+  const blob = await vercelBlob.put(
+    `some/new-folder/file-with-chars%20!'()@@{}[]-#?file.txt`,
+    'Hello, world!é',
+    {
+      access: 'public',
+      onUploadProgress(progressEvent) {
+        console.log(progressEvent.percentage);
+      },
     },
-  });
+  );
+  const head = await vercelBlob.head(blob.url);
+  console.log(head);
+  const copy = await vercelBlob.copy(
+    blob.url,
+    `some/even-new-folder/file-with-chars%20!'()@@{}[]-#?file.txt`,
+    {
+      access: 'public',
+    },
+  );
+  console.log(copy);
   console.log('Text file example:', blob.url, `(${Date.now() - start}ms)`);
   return blob.url;
 }


### PR DESCRIPTION
Before this commit, we would fail and even refuse to create files that contained
special characters like `#` `!` `%` `'` `"`.

We've since prepared an API update of the Vercel Blob API to allow any character
to be used and properly hanlded.

Fixes #828
