### PR TITLE
[@vercel/kv, @vercel/postgres, @vercel/postgres-kysely] Add notices to READMEs

### DIFF
--- a/packages/kv/README.md
+++ b/packages/kv/README.md
@@ -2,7 +2,7 @@
 
 <!-- prettier-ignore -->
 > [!CAUTION]
-> **`@vercel/kv` has moved to [the `@upstash/redis` package from Upstash](https://github.com/upstash/redis-js).
+> **`@vercel/kv` has moved to [the `@upstash/redis` package from Upstash](https://github.com/upstash/redis-js).** This retains the same first-party billing and integration into Vercel, with the added ability to open your Redis stores directly in Upstash.
 
 A client that works with Vercel KV.
 

--- a/packages/kv/README.md
+++ b/packages/kv/README.md
@@ -1,5 +1,9 @@
 # @vercel/kv
 
+<!-- prettier-ignore -->
+> [!CAUTION]
+> **`@vercel/kv` has moved to [the `@upstash/redis` package from Upstash](https://github.com/upstash/redis-js).
+
 A client that works with Vercel KV.
 
 ## Install

--- a/packages/postgres-kysely/README.md
+++ b/packages/postgres-kysely/README.md
@@ -1,5 +1,9 @@
 # @vercel/postgres-kysely
 
+<!-- prettier-ignore -->
+> [!CAUTION]
+> **`@vercel/postgres-kysely` has moved to the [`@neondatabase/serverless` package from Neon instead](https://github.com/neondatabase/serverless).** For a complete example of its implementation, check out the [neondatabase-labs/neon-vercel-kysely](https://github.com/neondatabase-labs/neon-vercel-kysely) repository.
+
 A `@vercel/postgres` wrapper for the [Kysely](https://github.com/kysely-org/kysely) query builder.
 
 ## Quick Start

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -1,5 +1,9 @@
 # @vercel/postgres
 
+<!-- prettier-ignore -->
+> [!CAUTION]
+> **`@vercel/postgres` has moved to the [`@neondatabase/serverless` package from Neon instead](https://github.com/neondatabase/serverless).** See the [Vercel Postgres to Neon transition guide](https://neon.tech/docs/guides/vercel-postgres-transition-guide).
+
 A client that works with Vercel Postgres.
 
 ## Quick Start


### PR DESCRIPTION
This PR adds notices to the READMEs of `@vercel/kv`, `@vercel/postgres` and `@vercel/postgres-kysely`. The Vercel KV and Vercel Postgres have transitioned over to Neon and Upstash in the Vercel Marketplace, unlocking the full potential of both platforms for Vercel customers. As a consequence, we are recommending `@vercel/kv` in favour of Upstash's `@upstash/redis` module and `@vercel/postgres` in favour of Neon's `@neondatabase/serverless`. These modules were essentially just wrappers around these modules anyway (with some added bells and whistles and API sprinkles). `npm` deprecation notices will follow soon.