### PR TITLE
feat(@vercel/blob): Default to not overwriting while allowing to bypass

### DIFF
--- a/packages/blob/src/client.ts
+++ b/packages/blob/src/client.ts
@@ -63,10 +63,12 @@ function createPutExtraChecks<
       // @ts-expect-error -- Runtime check for DX.
       options.addRandomSuffix !== undefined ||
       // @ts-expect-error -- Runtime check for DX.
+      options.allowOverwrite !== undefined ||
+      // @ts-expect-error -- Runtime check for DX.
       options.cacheControlMaxAge !== undefined
     ) {
       throw new BlobError(
-        `${methodName} doesn't allow addRandomSuffix and cacheControlMaxAge. Configure these options at the server side when generating client tokens.`,
+        `${methodName} doesn't allow \`addRandomSuffix\`, \`cacheControlMaxAge\` or \`allowOverwrite\`. Configure these options at the server side when generating client tokens.`,
       );
     }
   };
@@ -168,10 +170,12 @@ export const upload = createPutMethod<UploadOptions>({
       // @ts-expect-error -- Runtime check for DX.
       options.addRandomSuffix !== undefined ||
       // @ts-expect-error -- Runtime check for DX.
+      options.createPutExtraChecks !== undefined ||
+      // @ts-expect-error -- Runtime check for DX.
       options.cacheControlMaxAge !== undefined
     ) {
       throw new BlobError(
-        "client/`upload` doesn't allow addRandomSuffix and cacheControlMaxAge. Configure these options at the server side when generating client tokens.",
+        "client/`upload` doesn't allow `addRandomSuffix`, `cacheControlMaxAge` or `allowOverwrite`. Configure these options at the server side when generating client tokens.",
       );
     }
   },
@@ -319,6 +323,7 @@ export interface HandleUploadOptions {
       | 'maximumSizeInBytes'
       | 'validUntil'
       | 'addRandomSuffix'
+      | 'allowOverwrite'
       | 'cacheControlMaxAge'
     > & { tokenPayload?: string | null }
   >;
@@ -505,6 +510,7 @@ export interface GenerateClientTokenOptions extends BlobCommandOptions {
   allowedContentTypes?: string[];
   validUntil?: number;
   addRandomSuffix?: boolean;
+  allowOverwrite?: boolean;
   cacheControlMaxAge?: number;
 }
 

--- a/packages/blob/src/copy.ts
+++ b/packages/blob/src/copy.ts
@@ -55,6 +55,10 @@ export async function copy(
     headers['x-add-random-suffix'] = options.addRandomSuffix ? '1' : '0';
   }
 
+  if (options.allowOverwrite !== undefined) {
+    headers['x-allow-overwrite'] = options.allowOverwrite ? '1' : '0';
+  }
+
   if (options.contentType) {
     headers['x-content-type'] = options.contentType;
   }

--- a/packages/blob/src/helpers.ts
+++ b/packages/blob/src/helpers.ts
@@ -33,6 +33,11 @@ export interface CommonCreateBlobOptions extends BlobCommandOptions {
    */
   addRandomSuffix?: boolean;
   /**
+   * Allow overwriting an existing blob. By default this is set to false and will throw an error if the blob already exists.
+   * @defaultvalue false
+   */
+  allowOverwrite?: boolean;
+  /**
    * Defines the content type of the blob. By default, this value is inferred from the pathname. Sent as the 'content-type' header when downloading a blob.
    */
   contentType?: string;

--- a/packages/blob/src/index.ts
+++ b/packages/blob/src/index.ts
@@ -48,7 +48,12 @@ export type { PutCommandOptions };
  * @param options - Additional options like `token` or `contentType`.
  */
 export const put = createPutMethod<PutCommandOptions>({
-  allowedOptions: ['cacheControlMaxAge', 'addRandomSuffix', 'contentType'],
+  allowedOptions: [
+    'cacheControlMaxAge',
+    'addRandomSuffix',
+    'allowOverwrite',
+    'contentType',
+  ],
 });
 
 //  vercelBlob.del()
@@ -82,23 +87,43 @@ export { copy } from './copy';
 
 export const createMultipartUpload =
   createCreateMultipartUploadMethod<CommonCreateBlobOptions>({
-    allowedOptions: ['cacheControlMaxAge', 'addRandomSuffix', 'contentType'],
+    allowedOptions: [
+      'cacheControlMaxAge',
+      'addRandomSuffix',
+      'allowOverwrite',
+      'contentType',
+    ],
   });
 
 export const createMultipartUploader =
   createCreateMultipartUploaderMethod<CommonCreateBlobOptions>({
-    allowedOptions: ['cacheControlMaxAge', 'addRandomSuffix', 'contentType'],
+    allowedOptions: [
+      'cacheControlMaxAge',
+      'addRandomSuffix',
+      'allowOverwrite',
+      'contentType',
+    ],
   });
 
 export type { UploadPartCommandOptions };
 export const uploadPart = createUploadPartMethod<UploadPartCommandOptions>({
-  allowedOptions: ['cacheControlMaxAge', 'addRandomSuffix', 'contentType'],
+  allowedOptions: [
+    'cacheControlMaxAge',
+    'addRandomSuffix',
+    'allowOverwrite',
+    'contentType',
+  ],
 });
 
 export type { CompleteMultipartUploadCommandOptions };
 export const completeMultipartUpload =
   createCompleteMultipartUploadMethod<CompleteMultipartUploadCommandOptions>({
-    allowedOptions: ['cacheControlMaxAge', 'addRandomSuffix', 'contentType'],
+    allowedOptions: [
+      'cacheControlMaxAge',
+      'addRandomSuffix',
+      'allowOverwrite',
+      'contentType',
+    ],
   });
 
 export type { Part, PartInput } from './multipart/helpers';

--- a/packages/blob/src/put-helpers.ts
+++ b/packages/blob/src/put-helpers.ts
@@ -12,6 +12,7 @@ import { MAXIMUM_PATHNAME_LENGTH } from './api';
 export const putOptionHeaderMap = {
   cacheControlMaxAge: 'x-cache-control-max-age',
   addRandomSuffix: 'x-add-random-suffix',
+  allowOverwrite: 'x-allow-overwrite',
   contentType: 'x-content-type',
 };
 
@@ -58,6 +59,15 @@ export function createPutHeaders<TOptions extends CommonPutCommandOptions>(
     options.addRandomSuffix !== undefined
   ) {
     headers[putOptionHeaderMap.addRandomSuffix] = options.addRandomSuffix
+      ? '1'
+      : '0';
+  }
+
+  if (
+    allowedOptions.includes('allowOverwrite') &&
+    options.allowOverwrite !== undefined
+  ) {
+    headers[putOptionHeaderMap.allowOverwrite] = options.allowOverwrite
       ? '1'
       : '0';
   }


### PR DESCRIPTION
Added `allowOverwrite` option to Vercel Blob API to enable overwriting existing blobs.