### PR TITLE
fix(blob): Use new endpoint for API calls

### DIFF
--- a/.github/workflows/integration-tests-dev.yml
+++ b/.github/workflows/integration-tests-dev.yml
@@ -55,12 +55,6 @@ jobs:
         env:
           BLOB_UPLOAD_SECRET: ${{ secrets.BLOB_UPLOAD_SECRET }}
 
-      - name: Run Blob Playwright tests in development mode using the alternative api
-        run: pnpm integration-test -- @vercel/blob
-        env:
-          BLOB_UPLOAD_SECRET: ${{ secrets.BLOB_UPLOAD_SECRET }}
-          VERCEL_BLOB_API_URL: 'https://vercel.com/api/blob'
-
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/packages/blob/src/api.node.test.ts
+++ b/packages/blob/src/api.node.test.ts
@@ -35,7 +35,7 @@ describe('api', () => {
       process.env.BLOB_READ_WRITE_TOKEN = undefined;
 
       await expect(
-        requestApi('/api', { method: 'GET' }, undefined),
+        requestApi('/method', { method: 'GET' }, undefined),
       ).rejects.toThrow(BlobError);
 
       expect(fetchMock).toHaveBeenCalledTimes(0);
@@ -51,7 +51,7 @@ describe('api', () => {
       );
 
       const res = await requestApi<{ success: boolean }>(
-        '/api',
+        '/method',
         { method: 'POST', body: JSON.stringify({ foo: 'bar' }) },
         { token: '123' },
       );
@@ -59,14 +59,14 @@ describe('api', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenNthCalledWith(
         1,
-        'https://blob.vercel-storage.com/api',
+        'https://vercel.com/api/blob/method',
         {
           body: '{"foo":"bar"}',
           headers: {
             authorization: 'Bearer 123',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': expect.any(String) as string,
-            'x-api-version': '10',
+            'x-api-version': '11',
           },
           method: 'POST',
         },

--- a/packages/blob/src/api.ts
+++ b/packages/blob/src/api.ts
@@ -126,7 +126,7 @@ export interface BlobApiError {
 // This version is used to ensure that the client and server are compatible
 // The server (Vercel Blob API) uses this information to change its behavior like the
 // response format
-const BLOB_API_VERSION = 10;
+const BLOB_API_VERSION = 11;
 
 function getApiVersion(): string {
   let versionOverride = null;

--- a/packages/blob/src/client.browser.test.ts
+++ b/packages/blob/src/client.browser.test.ts
@@ -85,14 +85,14 @@ describe('client', () => {
       );
       expect(fetchMock).toHaveBeenNthCalledWith(
         2,
-        'https://blob.vercel-storage.com/?pathname=foo.txt',
+        'https://vercel.com/api/blob/?pathname=foo.txt',
         {
           body: 'Test file data',
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_123',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '10',
+            'x-api-version': '11',
           },
           method: 'PUT',
         },
@@ -201,13 +201,13 @@ describe('client', () => {
 
       expect(fetchMock).toHaveBeenNthCalledWith(
         1,
-        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
+        'https://vercel.com/api/blob/mpu?pathname=foo.txt',
         {
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '10',
+            'x-api-version': '11',
             'x-mpu-action': 'create',
           },
           method: 'POST',
@@ -217,14 +217,14 @@ describe('client', () => {
       const internalAbortSignal = new AbortController().signal;
       expect(fetchMock).toHaveBeenNthCalledWith(
         2,
-        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
+        'https://vercel.com/api/blob/mpu?pathname=foo.txt',
         {
           body: 'data1',
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '10',
+            'x-api-version': '11',
             'x-mpu-action': 'upload',
             'x-mpu-key': 'key',
             'x-mpu-upload-id': 'uploadId',
@@ -236,14 +236,14 @@ describe('client', () => {
       );
       expect(fetchMock).toHaveBeenNthCalledWith(
         3,
-        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
+        'https://vercel.com/api/blob/mpu?pathname=foo.txt',
         {
           body: 'data2',
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '10',
+            'x-api-version': '11',
             'x-mpu-action': 'upload',
             'x-mpu-key': 'key',
             'x-mpu-upload-id': 'uploadId',
@@ -255,7 +255,7 @@ describe('client', () => {
       );
       expect(fetchMock).toHaveBeenNthCalledWith(
         4,
-        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
+        'https://vercel.com/api/blob/mpu?pathname=foo.txt',
         {
           body: JSON.stringify([
             { etag: 'etag1', partNumber: 1 },
@@ -266,7 +266,7 @@ describe('client', () => {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '10',
+            'x-api-version': '11',
             'x-mpu-action': 'complete',
             'x-mpu-key': 'key',
             'x-mpu-upload-id': 'uploadId',
@@ -343,13 +343,13 @@ describe('client', () => {
 
       expect(fetchMock).toHaveBeenNthCalledWith(
         1,
-        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
+        'https://vercel.com/api/blob/mpu?pathname=foo.txt',
         {
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '10',
+            'x-api-version': '11',
             'x-mpu-action': 'create',
           },
           method: 'POST',
@@ -359,14 +359,14 @@ describe('client', () => {
       const internalAbortSignal = new AbortController().signal;
       expect(fetchMock).toHaveBeenNthCalledWith(
         2,
-        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
+        'https://vercel.com/api/blob/mpu?pathname=foo.txt',
         {
           body: 'data1',
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '10',
+            'x-api-version': '11',
             'x-mpu-action': 'upload',
             'x-mpu-key': 'key',
             'x-mpu-upload-id': 'uploadId',
@@ -378,14 +378,14 @@ describe('client', () => {
       );
       expect(fetchMock).toHaveBeenNthCalledWith(
         3,
-        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
+        'https://vercel.com/api/blob/mpu?pathname=foo.txt',
         {
           body: 'data2',
           headers: {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '10',
+            'x-api-version': '11',
             'x-mpu-action': 'upload',
             'x-mpu-key': 'key',
             'x-mpu-upload-id': 'uploadId',
@@ -397,7 +397,7 @@ describe('client', () => {
       );
       expect(fetchMock).toHaveBeenNthCalledWith(
         4,
-        'https://blob.vercel-storage.com/mpu?pathname=foo.txt',
+        'https://vercel.com/api/blob/mpu?pathname=foo.txt',
         {
           body: JSON.stringify([
             { etag: 'etag1', partNumber: 1 },
@@ -408,7 +408,7 @@ describe('client', () => {
             authorization: 'Bearer vercel_blob_client_fake_token_for_test',
             'x-api-blob-request-attempt': '0',
             'x-api-blob-request-id': `fake:${Date.now()}:${requestId}`,
-            'x-api-version': '10',
+            'x-api-version': '11',
             'x-mpu-action': 'complete',
             'x-mpu-key': 'key',
             'x-mpu-upload-id': 'uploadId',

--- a/packages/blob/src/helpers.ts
+++ b/packages/blob/src/helpers.ts
@@ -9,6 +9,8 @@ import type { PutBody } from './put-helpers';
 
 export { bytes } from './bytes';
 
+const defaultVercelBlobApiUrl = 'https://vercel.com/api/blob';
+
 export interface BlobCommandOptions {
   /**
    * Define your blob API token.
@@ -205,7 +207,7 @@ export function getApiUrl(pathname = ''): string {
     // noop
   }
 
-  return `${baseUrl || 'https://blob.vercel-storage.com'}${pathname}`;
+  return `${baseUrl || defaultVercelBlobApiUrl}${pathname}`;
 }
 
 const TEXT_ENCODER =

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -11,7 +11,7 @@ import {
   completeMultipartUpload,
 } from './index';
 
-const BLOB_API_URL = 'https://blob.vercel-storage.com';
+const BLOB_API_URL_AGENT = 'https://vercel.com';
 const BLOB_STORE_BASE_URL = 'https://storeId.public.blob.vercel-storage.com';
 
 const mockedFileMeta = {
@@ -33,7 +33,7 @@ describe('blob client', () => {
     const mockAgent = new MockAgent();
     mockAgent.disableNetConnect();
     setGlobalDispatcher(mockAgent);
-    mockClient = mockAgent.get(BLOB_API_URL);
+    mockClient = mockAgent.get(BLOB_API_URL_AGENT);
     jest.resetAllMocks();
 
     process.env.VERCEL_BLOB_RETRIES = '0';
@@ -68,7 +68,7 @@ describe('blob client', () => {
               }
           `);
       expect(path).toEqual(
-        '/?url=https%3A%2F%2FstoreId.public.blob.vercel-storage.com%2Ffoo-id.txt',
+        '/api/blob?url=https%3A%2F%2FstoreId.public.blob.vercel-storage.com%2Ffoo-id.txt',
       );
       expect(headers.authorization).toEqual(
         'Bearer vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678',
@@ -189,7 +189,7 @@ describe('blob client', () => {
         del(`${BLOB_STORE_BASE_URL}/foo-id.txt`),
       ).resolves.toBeUndefined();
 
-      expect(path).toEqual('/delete');
+      expect(path).toEqual('/api/blob/delete');
       expect(headers.authorization).toEqual(
         'Bearer vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678',
       );
@@ -220,7 +220,7 @@ describe('blob client', () => {
           `${BLOB_STORE_BASE_URL}/foo-id2.txt`,
         ]),
       ).resolves.toBeUndefined();
-      expect(path).toEqual('/delete');
+      expect(path).toEqual('/api/blob/delete');
       expect(headers.authorization).toEqual(
         'Bearer vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678',
       );
@@ -311,7 +311,9 @@ describe('blob client', () => {
           "hasMore": true,
         }
       `);
-      expect(path).toBe('/?limit=10&prefix=test-prefix&cursor=cursor-abc');
+      expect(path).toBe(
+        '/api/blob?limit=10&prefix=test-prefix&cursor=cursor-abc',
+      );
       expect(headers.authorization).toEqual(
         'Bearer vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678',
       );
@@ -383,7 +385,7 @@ describe('blob client', () => {
         }
       `);
 
-      expect(path).toBe('/?mode=folded');
+      expect(path).toBe('/api/blob?mode=folded');
     });
   });
 
@@ -455,7 +457,7 @@ describe('blob client', () => {
           "url": "https://storeId.public.blob.vercel-storage.com/foo-id.txt",
         }
       `);
-      expect(path).toBe('/?pathname=foo.txt');
+      expect(path).toBe('/api/blob/?pathname=foo.txt');
       expect(headers.authorization).toEqual('Bearer NEW_TOKEN');
       expect(body).toMatchInlineSnapshot(`"Test Body"`);
     });


### PR DESCRIPTION
### TL;DR

Updated Vercel Blob API endpoint URL and version to use the new API path structure.

### What changed?

- Changed the Blob API base URL from `https://blob.vercel-storage.com` to `https://vercel.com/api/blob`
- Updated the API version from `10` to `11`
- Updated all API endpoint paths in tests to reflect the new URL structure
- Modified test assertions to match the new endpoint patterns

### Why make this change?

This change aligns the Blob API with Vercel's standard API URL structure, consolidating all Vercel APIs under the same domain. The version bump to `11` ensures compatibility with the new endpoint structure and allows the server to properly handle requests from updated clients.

We've also seen cases where requests were failing and using vercel.com/api solves that.

fixes #853