### PR TITLE
chore(docs): Use urlOrPathname when relevant

### DIFF
--- a/.changeset/huge-coats-try.md
+++ b/.changeset/huge-coats-try.md
@@ -1,0 +1,5 @@
+---
+'@vercel/blob': patch
+---
+
+copy, head and del can receive a blob url or pathname, until now it was not very clear.

--- a/packages/blob/src/copy.ts
+++ b/packages/blob/src/copy.ts
@@ -16,12 +16,12 @@ export interface CopyBlobResult {
  * Copies a blob to another location in your store.
  * Detailed documentation can be found here: https://vercel.com/docs/vercel-blob/using-blob-sdk#copy-a-blob
  *
- * @param fromUrl - The blob URL to copy. You can only copy blobs that are in the store, that your 'BLOB_READ_WRITE_TOKEN' has access to.
+ * @param fromUrlOrPathname - The blob URL (or pathname) to copy. You can only copy blobs that are in the store, that your 'BLOB_READ_WRITE_TOKEN' has access to.
  * @param toPathname - The pathname to copy the blob to. This includes the filename.
  * @param options - Additional options. The copy method will not preserve any metadata configuration (e.g.: 'cacheControlMaxAge') of the source blob. If you want to copy the metadata, you need to define it here again.
  */
 export async function copy(
-  fromUrl: string,
+  fromUrlOrPathname: string,
   toPathname: string,
   options: CopyCommandOptions,
 ): Promise<CopyBlobResult> {
@@ -67,7 +67,10 @@ export async function copy(
     headers['x-cache-control-max-age'] = options.cacheControlMaxAge.toString();
   }
 
-  const params = new URLSearchParams({ pathname: toPathname, fromUrl });
+  const params = new URLSearchParams({
+    pathname: toPathname,
+    fromUrl: fromUrlOrPathname,
+  });
 
   const response = await requestApi<CopyBlobResult>(
     `?${params.toString()}`,

--- a/packages/blob/src/del.ts
+++ b/packages/blob/src/del.ts
@@ -5,11 +5,11 @@ import type { BlobCommandOptions } from './helpers';
  * Deletes one or multiple blobs from your store.
  * Detailed documentation can be found here: https://vercel.com/docs/vercel-blob/using-blob-sdk#delete-a-blob
  *
- * @param url - Blob url or array of blob urls that identify the blobs to be deleted. You can only delete blobs that are located in a store, that your 'BLOB_READ_WRITE_TOKEN' has access to.
+ * @param urlOrPathname - Blob url (or pathname) to delete. You can pass either a single value or an array of values. You can only delete blobs that are located in a store, that your 'BLOB_READ_WRITE_TOKEN' has access to.
  * @param options - Additional options for the request.
  */
 export async function del(
-  url: string[] | string,
+  urlOrPathname: string[] | string,
   options?: BlobCommandOptions,
 ): Promise<void> {
   await requestApi(
@@ -17,7 +17,9 @@ export async function del(
     {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ urls: Array.isArray(url) ? url : [url] }),
+      body: JSON.stringify({
+        urls: Array.isArray(urlOrPathname) ? urlOrPathname : [urlOrPathname],
+      }),
       signal: options?.abortSignal,
     },
     options,

--- a/packages/blob/src/head.ts
+++ b/packages/blob/src/head.ts
@@ -54,14 +54,14 @@ interface HeadBlobApiResponse extends Omit<HeadBlobResult, 'uploadedAt'> {
  * Fetches metadata of a blob object.
  * Detailed documentation can be found here: https://vercel.com/docs/vercel-blob/using-blob-sdk#get-blob-metadata
  *
- * @param url - Blob url to lookup.
+ * @param urlOrPathname - Blob url or pathname to lookup.
  * @param options - Additional options for the request.
  */
 export async function head(
-  url: string,
+  urlOrPathname: string,
   options?: BlobCommandOptions,
 ): Promise<HeadBlobResult> {
-  const searchParams = new URLSearchParams({ url });
+  const searchParams = new URLSearchParams({ url: urlOrPathname });
 
   const response = await requestApi<HeadBlobApiResponse>(
     `?${searchParams.toString()}`,


### PR DESCRIPTION
copy, head and del can receive a blob url or pathname, until now it was not very clear.