### PR TITLE
feat(@vercel/edge-config) Enforce an IO boundary around client APIs

### DIFF
--- a/.changeset/good-teeth-film.md
+++ b/.changeset/good-teeth-film.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': patch
+---
+
+make sure config reads are considered IO consistnetly

--- a/packages/edge-config/src/utils/io-boundary.ts
+++ b/packages/edge-config/src/utils/io-boundary.ts
@@ -1,0 +1,50 @@
+let blockedBoundary: null | Promise<void> = null;
+
+function getCurrentBoundary(): Promise<void> {
+  if (blockedBoundary) {
+    return blockedBoundary;
+  }
+  blockedBoundary = new Promise((resolve) => {
+    // We use setTimeout intentionally even in Node.js environments to ensure these
+    // are tracked as IO by React in Server Component environments.
+    // TODO implement a Next.js specific version so we can skip this boundary checking
+    // except where needed.
+    setTimeout(() => {
+      blockedBoundary = null;
+      resolve();
+    }, 0);
+  });
+  return blockedBoundary;
+}
+
+/**
+ * Wraps an async function to ensure that it will always yield to the event loop before
+ * resolving or rejecting.
+ */
+export function withIOBoundary<
+  /* eslint-disable @typescript-eslint/no-explicit-any -- we're wrapping */
+  F extends (...args: any[]) => Promise<any>,
+>(fn: F): F {
+  async function bounded(this: unknown, ...args: unknown[]): Promise<unknown> {
+    const boundary = getCurrentBoundary();
+    try {
+      /* eslint-disable @typescript-eslint/no-unsafe-return -- we're wrapping */
+      return await fn.call(this, ...args);
+    } finally {
+      await boundary;
+    }
+  }
+
+  try {
+    Object.defineProperty(bounded, 'name', { value: fn.name });
+  } catch {
+    // best effort
+  }
+  try {
+    Object.defineProperty(bounded, 'toString', { value: fn.toString.bind(fn) });
+  } catch {
+    // best effort
+  }
+
+  return bounded as F;
+}

--- a/packages/edge-config/src/utils/io-boundary.ts
+++ b/packages/edge-config/src/utils/io-boundary.ts
@@ -26,13 +26,8 @@ export function withIOBoundary<
   F extends (...args: any[]) => Promise<any>,
 >(fn: F): F {
   async function bounded(this: unknown, ...args: unknown[]): Promise<unknown> {
-    const boundary = getCurrentBoundary();
-    try {
-      /* eslint-disable @typescript-eslint/no-unsafe-return -- we're wrapping */
-      return await fn.call(this, ...args);
-    } finally {
-      await boundary;
-    }
+    await getCurrentBoundary();
+    return fn.call(this, ...args);
   }
 
   try {


### PR DESCRIPTION
Edge config is an IO library but it heavily caches the underlying IO to make reads incredibly fast. Next.js has a heuristic for prerenders that excludes IO. While we could argue that the kind of data edge-config provides is prerenderable because it has a long lifetime it is not clear that users expect this. To keep edge-config reads consistently treated as IO I've added a wrapper for the API methods which guarantees that any read will resolve in a future timeout task.

The choice of timeout is to align with React's IO semantics for what is and is not considered IO for purposes of Suspending. On edge runtimes this is unthrottled and should not add meaningful overhead. In Node.js this is at a minimum a 1ms delay if no other work takes time however since the edge config reads themselves may take longer than 1 ms often it won't be observed. Additionally as soon as one read is queued all subsequent reads that are initiated before the timeout executes will share the same boundary.

There is of course the possibility that previously scheduled events like immediates and OS IO can delay the unblocking of these APIs but if the workload is already CPU bound then reordering the resolution is not likely to meaningfully affect overall performance.

### Best reviewed with [whitespace ignored](https://github.com/vercel/storage/pull/878/files?w=1)