### PR TITLE
rework README

### DIFF
--- a/.changeset/cyan-beans-brush.md
+++ b/.changeset/cyan-beans-brush.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': patch
+---
+
+Adjust README

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -89,10 +89,6 @@ Edge Config Items can be managed in two ways:
 
 Keep in mind that Edge Config is built for very high read volume, but for infrequent writes.
 
-## Features
-
-- Works in [Edge Runtime](https://edge-runtime.vercel.sh/), [Node.js](https://nodejs.org) and in the browser
-
 ## Error Handling
 
 - An error is thrown in case of a network error
@@ -129,7 +125,15 @@ setTracerProvider(trace);
 
 More verbose traces can be enabled by setting the `EDGE_CONFIG_TRACE_VERBOSE` environment variable to `true`.
 
-## Fetch cache
+## Frameworks
+
+### Next.js
+
+#### Cache Components
+
+The Edge Config SDK supports [Cache Components](https://nextjs.org/docs/app/getting-started/cache-components) out of the box. Since Edge Config is a dynamic operation it always triggers dynamic mode unless you explicitly opt out as shown in the next section.
+
+##### Fetch cache
 
 By default the Edge Config SDK will fetch with `no-store`, which triggers dynamic mode in Next.js ([docs](https://nextjs.org/docs/app/api-reference/functions/fetch#optionscache)).
 
@@ -148,17 +152,7 @@ edgeConfigClient.get('someKey');
 
 **Note** This opts out of dynamic behavior, so the page might display stale values.
 
-## Notes
-
-### Do not mutate return values
-
-Cloning objects in JavaScript can be slow. That's why the Edge Config SDK uses an optimization which can lead to multiple calls reading the same key all receiving a reference to the same value.
-
-For this reason the value read from Edge Config should never be mutated, otherwise they could affect other parts of the code base reading the same key, or a later request reading the same key.
-
-If you need to modify, see the `clone` function described [here](#do-not-mutate-return-values).
-
-### Usage with Vite
+### Nuxt, SvelteKit and other vite based frameworks
 
 `@vercel/edge-config` reads database credentials from the environment variables on `process.env`. In general, `process.env` is automatically populated from your `.env` file during development, which is created when you run `vc env pull`. However, Vite does not expose the `.env` variables on `process.env.`
 
@@ -198,6 +192,16 @@ import { createClient } from '@vercel/edge-config';
 + const edgeConfig = createClient(EDGE_CONFIG);
 await edgeConfig.get('someKey');
 ```
+
+## Notes
+
+### Do not mutate return values
+
+Cloning objects in JavaScript can be slow. That's why the Edge Config SDK uses an optimization which can lead to multiple calls reading the same key all receiving a reference to the same value.
+
+For this reason the value read from Edge Config should never be mutated, otherwise they could affect other parts of the code base reading the same key, or a later request reading the same key.
+
+If you need to modify, see the `clone` function described [here](#do-not-mutate-return-values).
 
 ## Caught a Bug?
 

--- a/packages/edge-config/README.md
+++ b/packages/edge-config/README.md
@@ -1,7 +1,5 @@
 # @vercel/edge-config
 
-![Edge Runtime Compatible](https://img.shields.io/badge/edge--runtime-%E2%9C%94%20compatible-black)
-
 A client that lets you read Edge Config.
 
 ## Installation


### PR DESCRIPTION
Reworks the README

- Introduces Frameworks section
- Removes Edge Runtime badge
  - We're still Edge Runtime compatible but it's not something we want to highlight that prominently