### PR TITLE
Allow cacheLife to error

### DIFF
--- a/.changeset/thirty-dogs-play.md
+++ b/.changeset/thirty-dogs-play.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge-config': patch
+---
+
+Suppress errors thrown by cacheLife for contexts where the next-js condition is set but "use cache" functions are not turned into Cache Functions

--- a/packages/edge-config/src/index.next-js.ts
+++ b/packages/edge-config/src/index.next-js.ts
@@ -29,14 +29,22 @@ export {
 function setCacheLifeFromFetchCache(
   fetchCache: undefined | 'force-cache' | 'no-store',
 ): void {
-  if (fetchCache === 'force-cache') {
-    cacheLife('default');
-  } else {
-    // Working around a limitation of cacheLife in older Next.js versions
-    // where stale was required to be greater than expire if set concurrently.
-    // Instead we do this over two calls.
-    cacheLife({ revalidate: 0, expire: 0 });
-    cacheLife({ stale: 60 });
+  try {
+    if (fetchCache === 'force-cache') {
+      cacheLife('default');
+    } else {
+      // Working around a limitation of cacheLife in older Next.js versions
+      // where stale was required to be greater than expire if set concurrently.
+      // Instead we do this over two calls.
+      cacheLife({ revalidate: 0, expire: 0 });
+      cacheLife({ stale: 60 });
+    }
+  } catch {
+    // if we error setting cache life it means we are not in a cache scope
+    // The only time that might happen is if next-js entrypoint is used
+    // in a context that doesn't process the "use cache" directive.
+    // In these contexts we don't really need the cache life to be set because there
+    // is no Cache Component semantics
   }
 }
 


### PR DESCRIPTION
Next.js currently bundles proxy in a way that is indistinguishable from page code but in this context "use cache" isn't turned into a Cache Function so calls to `cacheLife` error. This will be fixed in Next.js but as an interrim fix we can just try/catch and suppress the error. This is safe for our context becasue we know we only call this from within "use cache" and we know that in any environment without "use cache" it should just fall back to normal behavior.

closes #891