### PR TITLE
align snapshot git sha release length

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -59,8 +59,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.node-version'
-          cache: 'pnpm'
+          node-version-file: ".node-version"
+          cache: "pnpm"
 
       - name: Add npm auth token to pnpm
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN_ELEVATED}"
@@ -71,7 +71,7 @@ jobs:
         run: pnpm install
 
       - name: Add SHORT_SHA env property with commit short sha
-        run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
+        run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-7`" >> $GITHUB_ENV
 
       - name: Version Packages
         run: pnpm changeset version --snapshot ${SHORT_SHA}


### PR DESCRIPTION
Aligns the length of the sha we make part of snapshot releases with the short-sha length used by GitHub such that we can correlate them more easily.