### PR TITLE
bypass preview deployment protection

### DIFF
--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -26,8 +26,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.node-version'
-          cache: 'pnpm'
+          node-version-file: ".node-version"
+          cache: "pnpm"
 
       - uses: actions/cache@v4
         id: playwright-cache
@@ -48,10 +48,11 @@ jobs:
       # this allows to use action cache, which is not possible when using deployment_status otherwise
       # see https://github.com/actions/cache/issues/319
       - name: Wait for Vercel Preview
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.1
+        uses: patrickedqvist/wait-for-vercel-preview@d0c786948cbb91d3a92fdfff2829e9066c232330
         id: waitForVercelPreview
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          vercel_protection_bypass_header: ${{ secrets.VERCEL_PROTECTION_BYPASS_HEADER }}
           max_timeout: 600
 
       - name: Run Playwright tests on ${{ steps.waitForVercelPreview.outputs.url }}
@@ -59,6 +60,7 @@ jobs:
         env:
           PLAYWRIGHT_TEST_BASE_URL: ${{ steps.waitForVercelPreview.outputs.url }}
           BLOB_UPLOAD_SECRET: ${{ secrets.BLOB_UPLOAD_SECRET }}
+          VERCEL_PROTECTION_BYPASS_HEADER: ${{ secrets.VERCEL_PROTECTION_BYPASS_HEADER }}
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -50,6 +50,8 @@ jobs:
       - name: Wait for Vercel Preview
         uses: patrickedqvist/wait-for-vercel-preview@v1.3.3
         id: waitForVercelPreview
+        env:
+          ACTIONS_STEP_DEBUG: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vercel_protection_bypass_header: ${{ secrets.VERCEL_PROTECTION_BYPASS_HEADER }}

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -48,7 +48,7 @@ jobs:
       # this allows to use action cache, which is not possible when using deployment_status otherwise
       # see https://github.com/actions/cache/issues/319
       - name: Wait for Vercel Preview
-        uses: patrickedqvist/wait-for-vercel-preview@d0c786948cbb91d3a92fdfff2829e9066c232330
+        uses: patrickedqvist/wait-for-vercel-preview@v1.3.3
         id: waitForVercelPreview
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -56,7 +56,8 @@ jobs:
           max_timeout: 600
 
       - name: Run Playwright tests on ${{ steps.waitForVercelPreview.outputs.url }}
-        run: pnpm integration-test
+        working-directory: test/next
+        run: pnpm exec playwright test
         env:
           PLAYWRIGHT_TEST_BASE_URL: ${{ steps.waitForVercelPreview.outputs.url }}
           BLOB_UPLOAD_SECRET: ${{ secrets.BLOB_UPLOAD_SECRET }}

--- a/.github/workflows/integration-tests-live.yml
+++ b/.github/workflows/integration-tests-live.yml
@@ -50,8 +50,6 @@ jobs:
       - name: Wait for Vercel Preview
         uses: patrickedqvist/wait-for-vercel-preview@v1.3.3
         id: waitForVercelPreview
-        env:
-          ACTIONS_STEP_DEBUG: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vercel_protection_bypass_header: ${{ secrets.VERCEL_PROTECTION_BYPASS_HEADER }}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "turbo build",
-    "integration-test": "turbo integration-test",
+    "integration-test": "turbo integration-test --output-logs=new-only",
     "check": "turbo check",
     "prepare": "husky",
     "check:fix": "biome check --write .",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 0.3.15
       ts-jest:
         specifier: 29.2.6
-        version: 29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.7.3)))(typescript@5.7.3)
+        version: 29.2.6(@babel/core@7.23.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.9))(jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.7.3)))(typescript@5.7.3)
       turbo:
         specifier: 2.4.4
         version: 2.4.4
@@ -77,7 +77,7 @@ importers:
         version: 29.7.0(bufferutil@4.0.8)
       ts-jest:
         specifier: 29.2.6
-        version: 29.2.6(@babel/core@7.23.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.2))(esbuild@0.25.0)(jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.7.3)))(typescript@5.7.3)
+        version: 29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.25.0)(jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.7.3)))(typescript@5.7.3)
       tsconfig:
         specifier: workspace:*
         version: link:../../tooling/tsconfig
@@ -117,13 +117,13 @@ importers:
         version: 3.0.3
       next:
         specifier: 16.0.10
-        version: 16.0.10(@babel/core@7.26.0)(@opentelemetry/api@1.7.0)(@playwright/test@1.55.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 16.0.10(@babel/core@7.26.0)(@opentelemetry/api@1.7.0)(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       node-domexception:
         specifier: 2.0.2
         version: 2.0.2
       ts-jest:
         specifier: 29.2.6
-        version: 29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.7.3)))(typescript@5.7.3)
+        version: 29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.25.0)(jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.7.3)))(typescript@5.7.3)
       tsconfig:
         specifier: workspace:*
         version: link:../../tooling/tsconfig
@@ -317,7 +317,7 @@ importers:
         version: 2.1.3
       next:
         specifier: 16.0.10
-        version: 16.0.10(@babel/core@7.26.0)(@opentelemetry/api@1.7.0)(@playwright/test@1.55.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 16.0.10(@babel/core@7.23.9)(@opentelemetry/api@1.7.0)(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
@@ -344,8 +344,8 @@ importers:
         version: 6.20.1
     devDependencies:
       '@playwright/test':
-        specifier: ^1.55.1
-        version: 1.55.1
+        specifier: ^1.57.0
+        version: 1.57.0
       '@types/json-stable-stringify':
         specifier: ^1.2.0
         version: 1.2.0
@@ -385,16 +385,16 @@ packages:
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/code-frame@7.27.1':
-    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+  '@babel/code-frame@7.28.6':
+    resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.23.5':
     resolution: {integrity: sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.28.5':
-    resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
+  '@babel/compat-data@7.28.6':
+    resolution: {integrity: sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.23.2':
@@ -417,16 +417,16 @@ packages:
     resolution: {integrity: sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.28.5':
-    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
+  '@babel/generator@7.28.6':
+    resolution: {integrity: sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.23.6':
     resolution: {integrity: sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.27.2':
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-environment-visitor@7.22.20':
@@ -449,8 +449,8 @@ packages:
     resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-transforms@7.23.3':
@@ -459,8 +459,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-module-transforms@7.28.3':
-    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -509,8 +509,8 @@ packages:
     resolution: {integrity: sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.4':
-    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
+  '@babel/helpers@7.28.6':
+    resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.22.13':
@@ -526,8 +526,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+  '@babel/parser@7.28.6':
+    resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -612,16 +612,16 @@ packages:
     resolution: {integrity: sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.27.2':
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.23.9':
     resolution: {integrity: sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.28.5':
-    resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
+  '@babel/traverse@7.28.6':
+    resolution: {integrity: sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.22.11':
@@ -632,8 +632,8 @@ packages:
     resolution: {integrity: sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+  '@babel/types@7.28.6':
+    resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -1443,8 +1443,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.55.1':
-    resolution: {integrity: sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==}
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1809,8 +1809,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  baseline-browser-mapping@2.9.3:
-    resolution: {integrity: sha512-8QdH6czo+G7uBsNo0GiUfouPN1lRzKdJTGnKXwe12gkFbnnOUaUKGN55dMkfy+mnxmvjwl9zcI4VncczcVXDhA==}
+  baseline-browser-mapping@2.9.17:
+    resolution: {integrity: sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==}
     hasBin: true
 
   better-path-resolve@1.0.0:
@@ -1915,6 +1915,9 @@ packages:
 
   caniuse-lite@1.0.30001759:
     resolution: {integrity: sha512-Pzfx9fOKoKvevQf8oCXoyNRQ5QyxJj+3O0Rqx2V5oxT61KGx8+n6hV/IUyJeifUci2clnmmKVpvtiqRzgiWjSw==}
+
+  caniuse-lite@1.0.30001766:
+    resolution: {integrity: sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -2176,8 +2179,8 @@ packages:
   electron-to-chromium@1.4.672:
     resolution: {integrity: sha512-YYCy+goe3UqZqa3MOQCI5Mx/6HdBLzXL/mkbGCEWL3sP3Z1BP9zqAzeD3YEmLZlespYGFtyM8tRp5i2vfaUGCA==}
 
-  electron-to-chromium@1.5.266:
-    resolution: {integrity: sha512-kgWEglXvkEfMH7rxP5OSZZwnaDWT7J9EoZCujhnpLbfi0bbNtRkgdX2E3gt0Uer11c61qCYktB3hwkAS325sJg==}
+  electron-to-chromium@1.5.277:
+    resolution: {integrity: sha512-wKXFZw4erWmmOz5N/grBoJ2XrNJGDFMu2+W5ACHza5rHtvsqrK4gb6rnLC7XxKB9WlJ+RmyQatuEXmtm86xbnw==}
 
   electron-to-chromium@1.5.83:
     resolution: {integrity: sha512-LcUDPqSt+V0QmI47XLzZrz5OqILSMGsPFkDYus22rIbgorSvBYEFqq854ltTmUdHkY92FSdAAvsh4jWEULMdfQ==}
@@ -3258,13 +3261,13 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  playwright-core@1.55.1:
-    resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.55.1:
-    resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==}
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3926,8 +3929,8 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  update-browserslist-db@1.2.2:
-    resolution: {integrity: sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==}
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -4095,7 +4098,7 @@ snapshots:
       '@babel/highlight': 7.23.4
       chalk: 2.4.2
 
-  '@babel/code-frame@7.27.1':
+  '@babel/code-frame@7.28.6':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
@@ -4104,7 +4107,7 @@ snapshots:
 
   '@babel/compat-data@7.23.5': {}
 
-  '@babel/compat-data@7.28.5':
+  '@babel/compat-data@7.28.6':
     optional: true
 
   '@babel/core@7.23.2':
@@ -4150,15 +4153,15 @@ snapshots:
   '@babel/core@7.26.0':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.26.0)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/code-frame': 7.28.6
+      '@babel/generator': 7.28.6
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.0)
+      '@babel/helpers': 7.28.6
+      '@babel/parser': 7.28.6
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.28.6
+      '@babel/types': 7.28.6
       convert-source-map: 2.0.0
       debug: 4.4.3
       gensync: 1.0.0-beta.2
@@ -4182,10 +4185,10 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.22
       jsesc: 2.5.2
 
-  '@babel/generator@7.28.5':
+  '@babel/generator@7.28.6':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -4199,9 +4202,9 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-compilation-targets@7.27.2':
+  '@babel/helper-compilation-targets@7.28.6':
     dependencies:
-      '@babel/compat-data': 7.28.5
+      '@babel/compat-data': 7.28.6
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.28.1
       lru-cache: 5.1.1
@@ -4226,10 +4229,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.23.9
 
-  '@babel/helper-module-imports@7.27.1':
+  '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.28.6
+      '@babel/types': 7.28.6
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -4252,12 +4255,12 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.26.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -4297,10 +4300,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helpers@7.28.4':
+  '@babel/helpers@7.28.6':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/template': 7.28.6
+      '@babel/types': 7.28.6
     optional: true
 
   '@babel/highlight@7.22.13':
@@ -4319,15 +4322,21 @@ snapshots:
     dependencies:
       '@babel/types': 7.23.9
 
-  '@babel/parser@7.28.5':
+  '@babel/parser@7.28.6':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.28.6
     optional: true
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.20.2
+
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.20.2
+    optional: true
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.26.0)':
     dependencies:
@@ -4340,6 +4349,12 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.20.2
 
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.20.2
+    optional: true
+
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
@@ -4350,6 +4365,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.20.2
+
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.20.2
+    optional: true
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.0)':
     dependencies:
@@ -4362,6 +4383,12 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.20.2
 
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.20.2
+    optional: true
+
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
@@ -4372,6 +4399,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.20.2
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.20.2
+    optional: true
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.0)':
     dependencies:
@@ -4389,6 +4422,12 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.20.2
 
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.20.2
+    optional: true
+
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
@@ -4399,6 +4438,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.20.2
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.20.2
+    optional: true
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.0)':
     dependencies:
@@ -4411,6 +4456,12 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.20.2
 
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.20.2
+    optional: true
+
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
@@ -4421,6 +4472,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.20.2
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.20.2
+    optional: true
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.0)':
     dependencies:
@@ -4433,6 +4490,12 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.20.2
 
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.20.2
+    optional: true
+
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
@@ -4444,6 +4507,12 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.20.2
 
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.20.2
+    optional: true
+
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
@@ -4454,6 +4523,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.20.2
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.20.2
+    optional: true
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.0)':
     dependencies:
@@ -4476,11 +4551,11 @@ snapshots:
       '@babel/parser': 7.23.9
       '@babel/types': 7.23.9
 
-  '@babel/template@7.27.2':
+  '@babel/template@7.28.6':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/code-frame': 7.28.6
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
     optional: true
 
   '@babel/traverse@7.23.9':
@@ -4498,14 +4573,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.28.5':
+  '@babel/traverse@7.28.6':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
+      '@babel/code-frame': 7.28.6
+      '@babel/generator': 7.28.6
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.28.6
+      '@babel/template': 7.28.6
+      '@babel/types': 7.28.6
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -4523,7 +4598,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
-  '@babel/types@7.28.5':
+  '@babel/types@7.28.6':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
@@ -5318,9 +5393,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.55.1':
+  '@playwright/test@1.57.0':
     dependencies:
-      playwright: 1.55.1
+      playwright: 1.57.0
 
   '@publint/pack@0.1.2': {}
 
@@ -5629,6 +5704,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-jest@29.7.0(@babel/core@7.23.9):
+    dependencies:
+      '@babel/core': 7.23.9
+      '@jest/transform': 29.7.0
+      '@types/babel__core': 7.20.0
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.23.9)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   babel-jest@29.7.0(@babel/core@7.26.0):
     dependencies:
       '@babel/core': 7.26.0
@@ -5676,6 +5765,23 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.2)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.2)
 
+  babel-preset-current-node-syntax@1.0.1(@babel/core@7.23.9):
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.9)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.23.9)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.9)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.9)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.9)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.9)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.9)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.9)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.9)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.9)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.9)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.9)
+    optional: true
+
   babel-preset-current-node-syntax@1.0.1(@babel/core@7.26.0):
     dependencies:
       '@babel/core': 7.26.0
@@ -5699,6 +5805,13 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.2)
 
+  babel-preset-jest@29.6.3(@babel/core@7.23.9):
+    dependencies:
+      '@babel/core': 7.23.9
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.9)
+    optional: true
+
   babel-preset-jest@29.6.3(@babel/core@7.26.0):
     dependencies:
       '@babel/core': 7.26.0
@@ -5708,7 +5821,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.9.3:
+  baseline-browser-mapping@2.9.17:
     optional: true
 
   better-path-resolve@1.0.0:
@@ -5746,11 +5859,11 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.9.3
-      caniuse-lite: 1.0.30001759
-      electron-to-chromium: 1.5.266
+      baseline-browser-mapping: 2.9.17
+      caniuse-lite: 1.0.30001766
+      electron-to-chromium: 1.5.277
       node-releases: 2.0.27
-      update-browserslist-db: 1.2.2(browserslist@4.28.1)
+      update-browserslist-db: 1.2.3(browserslist@4.28.1)
     optional: true
 
   bs-logger@0.2.6:
@@ -5824,6 +5937,9 @@ snapshots:
   caniuse-lite@1.0.30001692: {}
 
   caniuse-lite@1.0.30001759: {}
+
+  caniuse-lite@1.0.30001766:
+    optional: true
 
   chalk@2.4.2:
     dependencies:
@@ -6040,7 +6156,7 @@ snapshots:
 
   electron-to-chromium@1.4.672: {}
 
-  electron-to-chromium@1.5.266:
+  electron-to-chromium@1.5.277:
     optional: true
 
   electron-to-chromium@1.5.83: {}
@@ -7141,7 +7257,32 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.0.10(@babel/core@7.26.0)(@opentelemetry/api@1.7.0)(@playwright/test@1.55.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+  next@16.0.10(@babel/core@7.23.9)(@opentelemetry/api@1.7.0)(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      '@next/env': 16.0.10
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001759
+      postcss: 8.4.31
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      styled-jsx: 5.1.6(@babel/core@7.23.9)(react@19.2.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.0.10
+      '@next/swc-darwin-x64': 16.0.10
+      '@next/swc-linux-arm64-gnu': 16.0.10
+      '@next/swc-linux-arm64-musl': 16.0.10
+      '@next/swc-linux-x64-gnu': 16.0.10
+      '@next/swc-linux-x64-musl': 16.0.10
+      '@next/swc-win32-arm64-msvc': 16.0.10
+      '@next/swc-win32-x64-msvc': 16.0.10
+      '@opentelemetry/api': 1.7.0
+      '@playwright/test': 1.57.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.0.10(@babel/core@7.26.0)(@opentelemetry/api@1.7.0)(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@next/env': 16.0.10
       '@swc/helpers': 0.5.15
@@ -7160,7 +7301,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.0.10
       '@next/swc-win32-x64-msvc': 16.0.10
       '@opentelemetry/api': 1.7.0
-      '@playwright/test': 1.55.1
+      '@playwright/test': 1.57.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -7328,11 +7469,11 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  playwright-core@1.55.1: {}
+  playwright-core@1.57.0: {}
 
-  playwright@1.55.1:
+  playwright@1.57.0:
     dependencies:
-      playwright-core: 1.55.1
+      playwright-core: 1.57.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -7684,6 +7825,13 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  styled-jsx@5.1.6(@babel/core@7.23.9)(react@19.2.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.1
+    optionalDependencies:
+      '@babel/core': 7.23.9
+
   styled-jsx@5.1.6(@babel/core@7.26.0)(react@19.2.1):
     dependencies:
       client-only: 0.0.1
@@ -7824,7 +7972,7 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.26.0)
       esbuild: 0.24.2
 
-  ts-jest@29.2.6(@babel/core@7.23.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.2))(esbuild@0.25.0)(jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.7.3)))(typescript@5.7.3):
+  ts-jest@29.2.6(@babel/core@7.23.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.9))(jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.7.3)))(typescript@5.7.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -7838,13 +7986,12 @@ snapshots:
       typescript: 5.7.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.23.9
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.23.2)
-      esbuild: 0.25.0
+      babel-jest: 29.7.0(@babel/core@7.23.9)
 
-  ts-jest@29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.7.3)))(typescript@5.7.3):
+  ts-jest@29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.25.0)(jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.7.3)))(typescript@5.7.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -7862,6 +8009,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.0)
+      esbuild: 0.25.0
 
   ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3):
     dependencies:
@@ -8021,7 +8169,7 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  update-browserslist-db@1.2.2(browserslist@4.28.1):
+  update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
       escalade: 3.2.0

--- a/test/next/package.json
+++ b/test/next/package.json
@@ -36,7 +36,7 @@
     "undici": "^6.20.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.55.1",
+    "@playwright/test": "^1.57.0",
     "@types/json-stable-stringify": "^1.2.0",
     "json-stable-stringify": "^1.2.1"
   }

--- a/test/next/playwright.config.ts
+++ b/test/next/playwright.config.ts
@@ -27,6 +27,8 @@ const config: PlaywrightTestConfig = {
   retries: 5,
   // Artifacts folder where screenshots, videos, and traces are stored.
   outputDir: 'test-results/',
+  // Use line reporter for real-time progress in CI
+  reporter: process.env.CI ? 'line' : 'list',
 
   // Run your local dev server before starting the tests:
   // https://playwright.dev/docs/test-advanced#launching-a-development-web-server-during-the-tests

--- a/test/next/playwright.config.ts
+++ b/test/next/playwright.config.ts
@@ -40,6 +40,14 @@ const config: PlaywrightTestConfig = {
     // Retry a test if its failing with enabled tracing. This allows you to analyse the DOM, console logs, network traffic etc.
     // More information: https://playwright.dev/docs/trace-viewer
     trace: 'retry-with-trace',
+
+    // Add Vercel protection bypass header if provided
+    extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
+      ? {
+          'x-vercel-protection-bypass':
+            process.env.VERCEL_PROTECTION_BYPASS_HEADER,
+        }
+      : {},
   },
 
   projects: process.env.PLAYWRIGHT_PROJECT

--- a/test/next/playwright.config.ts
+++ b/test/next/playwright.config.ts
@@ -47,7 +47,7 @@ const config: PlaywrightTestConfig = {
           'x-vercel-protection-bypass':
             process.env.VERCEL_PROTECTION_BYPASS_HEADER,
         }
-      : {},
+      : undefined,
   },
 
   projects: process.env.PLAYWRIGHT_PROJECT

--- a/test/next/test/@vercel/blob/blob.visual.test.ts
+++ b/test/next/test/@vercel/blob/blob.visual.test.ts
@@ -7,7 +7,6 @@ const prefix =
 test.describe('@vercel/blob', () => {
   test.describe('page', () => {
     test('serverless', async ({ page }) => {
-      console.log(`vercel/pages/blob/image?prefix=${prefix}`);
       const response = await page.goto(
         `vercel/pages/blob/image?prefix=${prefix}`,
       );

--- a/test/next/test/@vercel/blob/blob.visual.test.ts
+++ b/test/next/test/@vercel/blob/blob.visual.test.ts
@@ -17,8 +17,10 @@ test.describe('@vercel/blob', () => {
       expect(response?.status()).toBe(200);
     });
   });
-  test.afterAll(async ({ request }) => {
+  test.afterAll(async ({ request, extraHTTPHeaders }) => {
     // cleanup all files
-    await request.delete(`vercel/blob/api/app/clean?prefix=${prefix}`);
+    await request.delete(`vercel/blob/api/app/clean?prefix=${prefix}`, {
+      headers: { ...extraHTTPHeaders },
+    });
   });
 });

--- a/test/next/test/@vercel/blob/index.test.ts
+++ b/test/next/test/@vercel/blob/index.test.ts
@@ -84,7 +84,14 @@ test.describe('@vercel/blob', () => {
         '/api/vercel/blob/pages/handle-blob-upload-serverless',
       ].forEach((callback) => {
         test(callback, async ({ browser }) => {
-          const browserContext = await browser.newContext();
+          const browserContext = await browser.newContext({
+            extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
+              ? {
+                  'x-vercel-protection-bypass':
+                    process.env.VERCEL_PROTECTION_BYPASS_HEADER,
+                }
+              : undefined,
+          });
           await browserContext.addCookies([
             {
               name: 'clientUpload',
@@ -114,7 +121,14 @@ test.describe('@vercel/blob', () => {
     test.describe('multipart upload', () => {
       test('multipart client upload', async ({ browser }) => {
         const callback = '/vercel/blob/api/app/handle-blob-upload/serverless';
-        const browserContext = await browser.newContext();
+        const browserContext = await browser.newContext({
+          extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
+            ? {
+                'x-vercel-protection-bypass':
+                  process.env.VERCEL_PROTECTION_BYPASS_HEADER,
+              }
+            : undefined,
+        });
         await browserContext.addCookies([
           {
             name: 'clientUpload',
@@ -195,8 +209,10 @@ test.describe('@vercel/blob', () => {
     });
   });
 
-  test.afterAll(async ({ request }) => {
+  test.afterAll(async ({ request, extraHTTPHeaders }) => {
     // cleanup all files
-    await request.delete(`vercel/blob/api/app/clean?prefix=${prefix}`);
+    await request.delete(`vercel/blob/api/app/clean?prefix=${prefix}`, {
+      headers: { ...extraHTTPHeaders },
+    });
   });
 });

--- a/test/next/test/@vercel/blob/index.test.ts
+++ b/test/next/test/@vercel/blob/index.test.ts
@@ -16,12 +16,13 @@ test.describe('@vercel/blob', () => {
       'api/vercel/blob/pages/edge',
       'api/vercel/blob/pages/serverless',
     ].forEach((path) => {
-      test(path, async ({ request }) => {
+      test(path, async ({ request, extraHTTPHeaders }) => {
         const data = (await request
           .post(`${path}?filename=${prefix}/test.txt`, {
             data: `Hello world ${path} ${prefix}`,
             headers: {
               cookie: `clientUpload=${process.env.BLOB_UPLOAD_SECRET ?? ''}`,
+              ...extraHTTPHeaders,
             },
           })
           .then((r) => r.json())) as PutBlobResult;
@@ -145,7 +146,7 @@ test.describe('@vercel/blob', () => {
           'api/vercel/blob/pages/edge',
           'api/vercel/blob/pages/serverless',
         ].forEach((path) => {
-          test(path, async ({ request }) => {
+          test(path, async ({ request, extraHTTPHeaders }) => {
             const data = (await request
               .post(`${path}?filename=${prefix}/test.txt&multipart=1`, {
                 data: `Hello world ${path} ${prefix}`,
@@ -153,6 +154,7 @@ test.describe('@vercel/blob', () => {
                   cookie: `clientUpload=${
                     process.env.BLOB_UPLOAD_SECRET ?? ''
                   }`,
+                  ...extraHTTPHeaders,
                 },
               })
               .then((r) => r.json())) as PutBlobResult;
@@ -170,7 +172,10 @@ test.describe('@vercel/blob', () => {
       });
 
       // https://github.com/vercel/storage/pull/616
-      test('multipart upload with buffer', async ({ request }) => {
+      test('multipart upload with buffer', async ({
+        request,
+        extraHTTPHeaders,
+      }) => {
         const path = 'vercel/blob/api/app/body/serverless';
         const imgPath = join(process.cwd(), 'images');
         const imageFile = readFileSync(join(imgPath, `g.jpeg`));
@@ -180,6 +185,7 @@ test.describe('@vercel/blob', () => {
             data: imageFile,
             headers: {
               cookie: `clientUpload=${process.env.BLOB_UPLOAD_SECRET ?? ''}`,
+              ...extraHTTPHeaders,
             },
           })
           .then((r) => r.json())) as PutBlobResult;

--- a/test/next/test/@vercel/blob/index.test.ts
+++ b/test/next/test/@vercel/blob/index.test.ts
@@ -76,16 +76,59 @@ test.describe('@vercel/blob', () => {
       );
     });
 
-    test.describe('client upload', () => {
-      [
-        '/vercel/blob/api/app/handle-blob-upload/serverless',
-        '/vercel/blob/api/app/handle-blob-upload/edge',
-        '/api/vercel/blob/pages/handle-blob-upload-edge',
-        '/api/vercel/blob/pages/handle-blob-upload-serverless',
-      ].forEach((callback) => {
-        test(callback, async ({ browser }) => {
-          // Increase test timeout for client uploads
+    // TODO: Re-enable once we debug why client uploads fail in CI
+    test.describe
+      .skip('client upload', () => {
+        [
+          '/vercel/blob/api/app/handle-blob-upload/serverless',
+          '/vercel/blob/api/app/handle-blob-upload/edge',
+          '/api/vercel/blob/pages/handle-blob-upload-edge',
+          '/api/vercel/blob/pages/handle-blob-upload-serverless',
+        ].forEach((callback) => {
+          test(callback, async ({ browser }) => {
+            // Increase test timeout for client uploads
+            test.setTimeout(120000);
+            const browserContext = await browser.newContext({
+              extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
+                ? {
+                    'x-vercel-protection-bypass':
+                      process.env.VERCEL_PROTECTION_BYPASS_HEADER,
+                  }
+                : undefined,
+            });
+            await browserContext.addCookies([
+              {
+                name: 'clientUpload',
+                value: process.env.BLOB_UPLOAD_SECRET ?? '',
+                path: '/',
+                domain: (
+                  process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'localhost'
+                ).replace('https://', ''),
+              },
+            ]);
+            const page = await browserContext.newPage();
+            await page.goto(
+              `vercel/blob/app/test/client?filename=${prefix}/test-app-client.txt&callback=${callback}`,
+            );
+
+            const textContent = await page.locator('#blob-path').textContent();
+            expect(textContent).toMatch(
+              new RegExp(`^${prefix}/test-app-client-.{30}\\.txt$`),
+            );
+            expect(await page.locator('#blob-content').textContent()).toBe(
+              `Hello from ${prefix}/test-app-client.txt`,
+            );
+          });
+        });
+      });
+
+    // TODO: Re-enable once we debug why client uploads fail in CI
+    test.describe
+      .skip('multipart upload', () => {
+        test('multipart client upload', async ({ browser }) => {
+          // Increase test timeout for multipart uploads
           test.setTimeout(120000);
+          const callback = '/vercel/blob/api/app/handle-blob-upload/serverless';
           const browserContext = await browser.newContext({
             extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
               ? {
@@ -106,7 +149,7 @@ test.describe('@vercel/blob', () => {
           ]);
           const page = await browserContext.newPage();
           await page.goto(
-            `vercel/blob/app/test/client?filename=${prefix}/test-app-client.txt&callback=${callback}`,
+            `vercel/blob/app/test/client?filename=${prefix}/test-app-client.txt&callback=${callback}&multipart=1`,
           );
 
           const textContent = await page.locator('#blob-path').textContent();
@@ -117,100 +160,61 @@ test.describe('@vercel/blob', () => {
             `Hello from ${prefix}/test-app-client.txt`,
           );
         });
-      });
-    });
 
-    test.describe('multipart upload', () => {
-      test('multipart client upload', async ({ browser }) => {
-        // Increase test timeout for multipart uploads
-        test.setTimeout(120000);
-        const callback = '/vercel/blob/api/app/handle-blob-upload/serverless';
-        const browserContext = await browser.newContext({
-          extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
-            ? {
-                'x-vercel-protection-bypass':
-                  process.env.VERCEL_PROTECTION_BYPASS_HEADER,
-              }
-            : undefined,
-        });
-        await browserContext.addCookies([
-          {
-            name: 'clientUpload',
-            value: process.env.BLOB_UPLOAD_SECRET ?? '',
-            path: '/',
-            domain: (
-              process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'localhost'
-            ).replace('https://', ''),
-          },
-        ]);
-        const page = await browserContext.newPage();
-        await page.goto(
-          `vercel/blob/app/test/client?filename=${prefix}/test-app-client.txt&callback=${callback}&multipart=1`,
-        );
-
-        const textContent = await page.locator('#blob-path').textContent();
-        expect(textContent).toMatch(
-          new RegExp(`^${prefix}/test-app-client-.{30}\\.txt$`),
-        );
-        expect(await page.locator('#blob-content').textContent()).toBe(
-          `Hello from ${prefix}/test-app-client.txt`,
-        );
-      });
-
-      test.describe('multipart server upload (app router)', () => {
-        [
-          'vercel/blob/api/app/body/edge',
-          'vercel/blob/api/app/body/serverless',
-          'api/vercel/blob/pages/edge',
-          'api/vercel/blob/pages/serverless',
-        ].forEach((path) => {
-          test(path, async ({ request, extraHTTPHeaders }) => {
-            const data = (await request
-              .post(`${path}?filename=${prefix}/test.txt&multipart=1`, {
-                data: `Hello world ${path} ${prefix}`,
-                headers: {
-                  cookie: `clientUpload=${
-                    process.env.BLOB_UPLOAD_SECRET ?? ''
-                  }`,
-                  ...extraHTTPHeaders,
-                },
-              })
-              .then((r) => r.json())) as PutBlobResult;
-            expect(data.contentDisposition).toBe(
-              `inline; filename="${getFilenameFromUrl(data.url)}"`,
-            );
-            expect(data.contentType).toBe('text/plain');
-            expect(data.pathname).toBe(
-              `${prefix}/${getFilenameFromUrl(data.url)}`,
-            );
-            const content = await request.get(data.url).then((r) => r.text());
-            expect(content).toBe(`Hello world ${path} ${prefix}`);
+        test.describe('multipart server upload (app router)', () => {
+          [
+            'vercel/blob/api/app/body/edge',
+            'vercel/blob/api/app/body/serverless',
+            'api/vercel/blob/pages/edge',
+            'api/vercel/blob/pages/serverless',
+          ].forEach((path) => {
+            test(path, async ({ request, extraHTTPHeaders }) => {
+              const data = (await request
+                .post(`${path}?filename=${prefix}/test.txt&multipart=1`, {
+                  data: `Hello world ${path} ${prefix}`,
+                  headers: {
+                    cookie: `clientUpload=${
+                      process.env.BLOB_UPLOAD_SECRET ?? ''
+                    }`,
+                    ...extraHTTPHeaders,
+                  },
+                })
+                .then((r) => r.json())) as PutBlobResult;
+              expect(data.contentDisposition).toBe(
+                `inline; filename="${getFilenameFromUrl(data.url)}"`,
+              );
+              expect(data.contentType).toBe('text/plain');
+              expect(data.pathname).toBe(
+                `${prefix}/${getFilenameFromUrl(data.url)}`,
+              );
+              const content = await request.get(data.url).then((r) => r.text());
+              expect(content).toBe(`Hello world ${path} ${prefix}`);
+            });
           });
         });
-      });
 
-      // https://github.com/vercel/storage/pull/616
-      test('multipart upload with buffer', async ({
-        request,
-        extraHTTPHeaders,
-      }) => {
-        const path = 'vercel/blob/api/app/body/serverless';
-        const imgPath = join(process.cwd(), 'images');
-        const imageFile = readFileSync(join(imgPath, `g.jpeg`));
+        // https://github.com/vercel/storage/pull/616
+        test('multipart upload with buffer', async ({
+          request,
+          extraHTTPHeaders,
+        }) => {
+          const path = 'vercel/blob/api/app/body/serverless';
+          const imgPath = join(process.cwd(), 'images');
+          const imageFile = readFileSync(join(imgPath, `g.jpeg`));
 
-        const data = (await request
-          .post(`${path}?filename=${prefix}/g.jpeg&multipart=1&useBuffer=1`, {
-            data: imageFile,
-            headers: {
-              cookie: `clientUpload=${process.env.BLOB_UPLOAD_SECRET ?? ''}`,
-              ...extraHTTPHeaders,
-            },
-          })
-          .then((r) => r.json())) as PutBlobResult;
-        const content = await request.head(data.url);
-        expect(content.headers()['content-length']).toEqual('19939');
+          const data = (await request
+            .post(`${path}?filename=${prefix}/g.jpeg&multipart=1&useBuffer=1`, {
+              data: imageFile,
+              headers: {
+                cookie: `clientUpload=${process.env.BLOB_UPLOAD_SECRET ?? ''}`,
+                ...extraHTTPHeaders,
+              },
+            })
+            .then((r) => r.json())) as PutBlobResult;
+          const content = await request.head(data.url);
+          expect(content.headers()['content-length']).toEqual('19939');
+        });
       });
-    });
   });
 
   test.afterAll(async ({ request, extraHTTPHeaders }) => {

--- a/test/next/test/@vercel/blob/index.test.ts
+++ b/test/next/test/@vercel/blob/index.test.ts
@@ -76,67 +76,20 @@ test.describe('@vercel/blob', () => {
       );
     });
 
-    // TODO: Re-enable once we debug why client uploads fail in CI
-    test.describe
-      .skip('client upload', () => {
-        [
-          '/vercel/blob/api/app/handle-blob-upload/serverless',
-          '/vercel/blob/api/app/handle-blob-upload/edge',
-          '/api/vercel/blob/pages/handle-blob-upload-edge',
-          '/api/vercel/blob/pages/handle-blob-upload-serverless',
-        ].forEach((callback) => {
-          test(callback, async ({ browser }) => {
-            // Increase test timeout for client uploads
-            test.setTimeout(120000);
-            const browserContext = await browser.newContext({
-              extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
-                ? {
-                    'x-vercel-protection-bypass':
-                      process.env.VERCEL_PROTECTION_BYPASS_HEADER,
-                  }
-                : undefined,
-            });
-            await browserContext.addCookies([
-              {
-                name: 'clientUpload',
-                value: process.env.BLOB_UPLOAD_SECRET ?? '',
-                path: '/',
-                domain: (
-                  process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'localhost'
-                ).replace('https://', ''),
-              },
-            ]);
-            const page = await browserContext.newPage();
-            await page.goto(
-              `vercel/blob/app/test/client?filename=${prefix}/test-app-client.txt&callback=${callback}`,
-            );
-
-            const textContent = await page.locator('#blob-path').textContent();
-            expect(textContent).toMatch(
-              new RegExp(`^${prefix}/test-app-client-.{30}\\.txt$`),
-            );
-            expect(await page.locator('#blob-content').textContent()).toBe(
-              `Hello from ${prefix}/test-app-client.txt`,
-            );
-          });
-        });
-      });
-
-    // TODO: Re-enable once we debug why client uploads fail in CI
-    test.describe
-      .skip('multipart upload', () => {
-        test('multipart client upload', async ({ browser }) => {
-          // Increase test timeout for multipart uploads
+    test.describe('client upload', () => {
+      [
+        '/vercel/blob/api/app/handle-blob-upload/serverless',
+        '/vercel/blob/api/app/handle-blob-upload/edge',
+        '/api/vercel/blob/pages/handle-blob-upload-edge',
+        '/api/vercel/blob/pages/handle-blob-upload-serverless',
+      ].forEach((callback) => {
+        test(callback, async ({ browser }) => {
+          // Increase test timeout for client uploads
           test.setTimeout(120000);
-          const callback = '/vercel/blob/api/app/handle-blob-upload/serverless';
-          const browserContext = await browser.newContext({
-            extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
-              ? {
-                  'x-vercel-protection-bypass':
-                    process.env.VERCEL_PROTECTION_BYPASS_HEADER,
-                }
-              : undefined,
-          });
+          // Don't use extraHTTPHeaders here - it applies to ALL requests including
+          // cross-origin blob API calls, which breaks CORS. Instead use page.route()
+          // to add the header only to preview deployment requests.
+          const browserContext = await browser.newContext();
           await browserContext.addCookies([
             {
               name: 'clientUpload',
@@ -148,8 +101,22 @@ test.describe('@vercel/blob', () => {
             },
           ]);
           const page = await browserContext.newPage();
+
+          // Add protection bypass header only for requests to the preview deployment
+          if (process.env.VERCEL_PROTECTION_BYPASS_HEADER) {
+            const baseUrl = process.env.PLAYWRIGHT_TEST_BASE_URL ?? '';
+            await page.route(`${baseUrl}/**`, async (route) => {
+              const headers = {
+                ...route.request().headers(),
+                'x-vercel-protection-bypass':
+                  process.env.VERCEL_PROTECTION_BYPASS_HEADER!,
+              };
+              await route.continue({ headers });
+            });
+          }
+
           await page.goto(
-            `vercel/blob/app/test/client?filename=${prefix}/test-app-client.txt&callback=${callback}&multipart=1`,
+            `vercel/blob/app/test/client?filename=${prefix}/test-app-client.txt&callback=${callback}`,
           );
 
           const textContent = await page.locator('#blob-path').textContent();
@@ -160,61 +127,110 @@ test.describe('@vercel/blob', () => {
             `Hello from ${prefix}/test-app-client.txt`,
           );
         });
+      });
+    });
 
-        test.describe('multipart server upload (app router)', () => {
-          [
-            'vercel/blob/api/app/body/edge',
-            'vercel/blob/api/app/body/serverless',
-            'api/vercel/blob/pages/edge',
-            'api/vercel/blob/pages/serverless',
-          ].forEach((path) => {
-            test(path, async ({ request, extraHTTPHeaders }) => {
-              const data = (await request
-                .post(`${path}?filename=${prefix}/test.txt&multipart=1`, {
-                  data: `Hello world ${path} ${prefix}`,
-                  headers: {
-                    cookie: `clientUpload=${
-                      process.env.BLOB_UPLOAD_SECRET ?? ''
-                    }`,
-                    ...extraHTTPHeaders,
-                  },
-                })
-                .then((r) => r.json())) as PutBlobResult;
-              expect(data.contentDisposition).toBe(
-                `inline; filename="${getFilenameFromUrl(data.url)}"`,
-              );
-              expect(data.contentType).toBe('text/plain');
-              expect(data.pathname).toBe(
-                `${prefix}/${getFilenameFromUrl(data.url)}`,
-              );
-              const content = await request.get(data.url).then((r) => r.text());
-              expect(content).toBe(`Hello world ${path} ${prefix}`);
-            });
+    test.describe('multipart upload', () => {
+      test('multipart client upload', async ({ browser }) => {
+        // Increase test timeout for multipart uploads
+        test.setTimeout(120000);
+        const callback = '/vercel/blob/api/app/handle-blob-upload/serverless';
+        // Don't use extraHTTPHeaders here - it applies to ALL requests including
+        // cross-origin blob API calls, which breaks CORS. Instead use page.route()
+        // to add the header only to preview deployment requests.
+        const browserContext = await browser.newContext();
+        await browserContext.addCookies([
+          {
+            name: 'clientUpload',
+            value: process.env.BLOB_UPLOAD_SECRET ?? '',
+            path: '/',
+            domain: (
+              process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'localhost'
+            ).replace('https://', ''),
+          },
+        ]);
+        const page = await browserContext.newPage();
+
+        // Add protection bypass header only for requests to the preview deployment
+        if (process.env.VERCEL_PROTECTION_BYPASS_HEADER) {
+          const baseUrl = process.env.PLAYWRIGHT_TEST_BASE_URL ?? '';
+          await page.route(`${baseUrl}/**`, async (route) => {
+            const headers = {
+              ...route.request().headers(),
+              'x-vercel-protection-bypass':
+                process.env.VERCEL_PROTECTION_BYPASS_HEADER!,
+            };
+            await route.continue({ headers });
+          });
+        }
+
+        await page.goto(
+          `vercel/blob/app/test/client?filename=${prefix}/test-app-client.txt&callback=${callback}&multipart=1`,
+        );
+
+        const textContent = await page.locator('#blob-path').textContent();
+        expect(textContent).toMatch(
+          new RegExp(`^${prefix}/test-app-client-.{30}\\.txt$`),
+        );
+        expect(await page.locator('#blob-content').textContent()).toBe(
+          `Hello from ${prefix}/test-app-client.txt`,
+        );
+      });
+
+      test.describe('multipart server upload (app router)', () => {
+        [
+          'vercel/blob/api/app/body/edge',
+          'vercel/blob/api/app/body/serverless',
+          'api/vercel/blob/pages/edge',
+          'api/vercel/blob/pages/serverless',
+        ].forEach((path) => {
+          test(path, async ({ request, extraHTTPHeaders }) => {
+            const data = (await request
+              .post(`${path}?filename=${prefix}/test.txt&multipart=1`, {
+                data: `Hello world ${path} ${prefix}`,
+                headers: {
+                  cookie: `clientUpload=${
+                    process.env.BLOB_UPLOAD_SECRET ?? ''
+                  }`,
+                  ...extraHTTPHeaders,
+                },
+              })
+              .then((r) => r.json())) as PutBlobResult;
+            expect(data.contentDisposition).toBe(
+              `inline; filename="${getFilenameFromUrl(data.url)}"`,
+            );
+            expect(data.contentType).toBe('text/plain');
+            expect(data.pathname).toBe(
+              `${prefix}/${getFilenameFromUrl(data.url)}`,
+            );
+            const content = await request.get(data.url).then((r) => r.text());
+            expect(content).toBe(`Hello world ${path} ${prefix}`);
           });
         });
-
-        // https://github.com/vercel/storage/pull/616
-        test('multipart upload with buffer', async ({
-          request,
-          extraHTTPHeaders,
-        }) => {
-          const path = 'vercel/blob/api/app/body/serverless';
-          const imgPath = join(process.cwd(), 'images');
-          const imageFile = readFileSync(join(imgPath, `g.jpeg`));
-
-          const data = (await request
-            .post(`${path}?filename=${prefix}/g.jpeg&multipart=1&useBuffer=1`, {
-              data: imageFile,
-              headers: {
-                cookie: `clientUpload=${process.env.BLOB_UPLOAD_SECRET ?? ''}`,
-                ...extraHTTPHeaders,
-              },
-            })
-            .then((r) => r.json())) as PutBlobResult;
-          const content = await request.head(data.url);
-          expect(content.headers()['content-length']).toEqual('19939');
-        });
       });
+
+      // https://github.com/vercel/storage/pull/616
+      test('multipart upload with buffer', async ({
+        request,
+        extraHTTPHeaders,
+      }) => {
+        const path = 'vercel/blob/api/app/body/serverless';
+        const imgPath = join(process.cwd(), 'images');
+        const imageFile = readFileSync(join(imgPath, `g.jpeg`));
+
+        const data = (await request
+          .post(`${path}?filename=${prefix}/g.jpeg&multipart=1&useBuffer=1`, {
+            data: imageFile,
+            headers: {
+              cookie: `clientUpload=${process.env.BLOB_UPLOAD_SECRET ?? ''}`,
+              ...extraHTTPHeaders,
+            },
+          })
+          .then((r) => r.json())) as PutBlobResult;
+        const content = await request.head(data.url);
+        expect(content.headers()['content-length']).toEqual('19939');
+      });
+    });
   });
 
   test.afterAll(async ({ request, extraHTTPHeaders }) => {

--- a/test/next/test/@vercel/blob/index.test.ts
+++ b/test/next/test/@vercel/blob/index.test.ts
@@ -84,6 +84,8 @@ test.describe('@vercel/blob', () => {
         '/api/vercel/blob/pages/handle-blob-upload-serverless',
       ].forEach((callback) => {
         test(callback, async ({ browser }) => {
+          // Increase test timeout for client uploads
+          test.setTimeout(120000);
           const browserContext = await browser.newContext({
             extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
               ? {
@@ -120,6 +122,8 @@ test.describe('@vercel/blob', () => {
 
     test.describe('multipart upload', () => {
       test('multipart client upload', async ({ browser }) => {
+        // Increase test timeout for multipart uploads
+        test.setTimeout(120000);
         const callback = '/vercel/blob/api/app/handle-blob-upload/serverless';
         const browserContext = await browser.newContext({
           extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER

--- a/test/next/test/@vercel/blob/progress.test.ts
+++ b/test/next/test/@vercel/blob/progress.test.ts
@@ -3,91 +3,91 @@ import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import type { UploadProgressEvent } from '@vercel/blob';
 
-test.describe('progress events', () => {
-  ['multipart=0', 'multipart=1'].forEach((searchParams) => {
-    test(`onUploadProgress client upload ${searchParams}`, async ({
-      browser,
-    }) => {
-      // Create a temporary test file
-      const testFilePath = join(
-        __dirname,
-        '..',
-        '..',
-        '..',
-        'public',
-        '15mb-video.mp4',
-      );
+test.describe
+  .skip('progress events', () => {
+    ['multipart=0', 'multipart=1'].forEach((searchParams) => {
+      test(`onUploadProgress client upload ${searchParams}`, async ({
+        browser,
+      }) => {
+        // Create a temporary test file
+        const testFilePath = join(
+          __dirname,
+          '..',
+          '..',
+          '..',
+          'public',
+          '15mb-video.mp4',
+        );
 
-      const sizeInBytes = statSync(testFilePath).size;
+        const sizeInBytes = statSync(testFilePath).size;
 
-      const browserContext = await browser.newContext();
-      await browserContext.addCookies([
-        {
-          name: 'clientUpload',
-          value: process.env.BLOB_UPLOAD_SECRET ?? '',
-          path: '/',
-          domain: (process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'localhost').replace(
-            'https://',
-            '',
-          ),
-        },
-      ]);
+        const browserContext = await browser.newContext();
+        await browserContext.addCookies([
+          {
+            name: 'clientUpload',
+            value: process.env.BLOB_UPLOAD_SECRET ?? '',
+            path: '/',
+            domain: (
+              process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'localhost'
+            ).replace('https://', ''),
+          },
+        ]);
 
-      const page = await browserContext.newPage();
-      await page.goto(`vercel/blob/app/client?${searchParams}`);
+        const page = await browserContext.newPage();
+        await page.goto(`vercel/blob/app/client?${searchParams}`);
 
-      // Get the file input and set the file
-      const fileInput = page.getByTestId('file-input');
-      await fileInput.setInputFiles(testFilePath);
+        // Get the file input and set the file
+        const fileInput = page.getByTestId('file-input');
+        await fileInput.setInputFiles(testFilePath);
 
-      // Click the upload button
-      await page.getByTestId('upload-button').click();
+        // Click the upload button
+        await page.getByTestId('upload-button').click();
 
-      // Wait for the blob result to appear and verify URL
-      const blobUrl = page.getByTestId('blob-url');
-      await expect(blobUrl).toBeVisible({ timeout: 15000 });
-      const url = await blobUrl.getAttribute('href');
-      expect(url).toBeDefined();
-      expect(url).toContain('15mb-video');
-      expect(url).toContain('.mp4');
+        // Wait for the blob result to appear and verify URL
+        const blobUrl = page.getByTestId('blob-url');
+        await expect(blobUrl).toBeVisible({ timeout: 1500000 });
+        const url = await blobUrl.getAttribute('href');
+        expect(url).toBeDefined();
+        expect(url).toContain('15mb-video');
+        expect(url).toContain('.mp4');
 
-      // Verify video player is present
-      await expect(page.getByTestId('video-player')).toBeVisible();
+        // Verify video player is present
+        await expect(page.getByTestId('video-player')).toBeVisible();
 
-      // Wait for and verify progress events
-      await expect(page.getByTestId('progress-events')).toBeVisible();
-      const progressEvents = await page
-        .getByTestId('progress-event-item')
-        .all();
-      expect(progressEvents.length).toBeGreaterThan(2);
+        // Wait for and verify progress events
+        await expect(page.getByTestId('progress-events')).toBeVisible();
+        const progressEvents = await page
+          .getByTestId('progress-event-item')
+          .all();
+        expect(progressEvents.length).toBeGreaterThan(2);
 
-      // Verify first event (0%)
-      const firstEventText = await progressEvents[0].textContent();
-      const firstEvent = JSON.parse(
-        firstEventText || '{}',
-      ) as UploadProgressEvent;
-      expect(firstEvent.loaded).toBe(0);
-      expect(firstEvent.total).toBe(sizeInBytes);
-      expect(firstEvent.percentage).toBe(0);
+        // Verify first event (0%)
+        const firstEventText = await progressEvents[0].textContent();
+        const firstEvent = JSON.parse(
+          firstEventText || '{}',
+        ) as UploadProgressEvent;
+        expect(firstEvent.loaded).toBe(0);
+        expect(firstEvent.total).toBe(sizeInBytes);
+        expect(firstEvent.percentage).toBe(0);
 
-      // Verify second event (>0%)
-      const secondEventText = await progressEvents[1].textContent();
-      const secondEvent = JSON.parse(
-        secondEventText || '{}',
-      ) as UploadProgressEvent;
-      expect(secondEvent.loaded).toBeGreaterThan(0);
-      expect(secondEvent.total).toBe(sizeInBytes);
-      expect(secondEvent.percentage).toBeGreaterThan(0);
+        // Verify second event (>0%)
+        const secondEventText = await progressEvents[1].textContent();
+        const secondEvent = JSON.parse(
+          secondEventText || '{}',
+        ) as UploadProgressEvent;
+        expect(secondEvent.loaded).toBeGreaterThan(0);
+        expect(secondEvent.total).toBe(sizeInBytes);
+        expect(secondEvent.percentage).toBeGreaterThan(0);
 
-      // Verify last event (100%)
-      const lastEventText =
-        await progressEvents[progressEvents.length - 1].textContent();
-      const lastEvent = JSON.parse(
-        lastEventText || '{}',
-      ) as UploadProgressEvent;
-      expect(lastEvent.loaded).toBe(sizeInBytes);
-      expect(lastEvent.total).toBe(sizeInBytes);
-      expect(lastEvent.percentage).toBe(100);
+        // Verify last event (100%)
+        const lastEventText =
+          await progressEvents[progressEvents.length - 1].textContent();
+        const lastEvent = JSON.parse(
+          lastEventText || '{}',
+        ) as UploadProgressEvent;
+        expect(lastEvent.loaded).toBe(sizeInBytes);
+        expect(lastEvent.total).toBe(sizeInBytes);
+        expect(lastEvent.percentage).toBe(100);
+      });
     });
   });
-});

--- a/test/next/test/@vercel/blob/progress.test.ts
+++ b/test/next/test/@vercel/blob/progress.test.ts
@@ -3,101 +3,110 @@ import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import type { UploadProgressEvent } from '@vercel/blob';
 
-// TODO: Re-enable once we debug why uploads fail in CI (they were originally skipped)
-test.describe
-  .skip('progress events', () => {
-    ['multipart=0', 'multipart=1'].forEach((searchParams) => {
-      test(`onUploadProgress client upload ${searchParams}`, async ({
-        browser,
-      }) => {
-        // Increase test timeout for 15MB upload
-        test.setTimeout(180000);
-        // Create a temporary test file
-        const testFilePath = join(
-          __dirname,
-          '..',
-          '..',
-          '..',
-          'public',
-          '15mb-video.mp4',
-        );
+test.describe('progress events', () => {
+  ['multipart=0', 'multipart=1'].forEach((searchParams) => {
+    test(`onUploadProgress client upload ${searchParams}`, async ({
+      browser,
+    }) => {
+      // Increase test timeout for 15MB upload
+      test.setTimeout(180000);
+      // Create a temporary test file
+      const testFilePath = join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        'public',
+        '15mb-video.mp4',
+      );
 
-        const sizeInBytes = statSync(testFilePath).size;
+      const sizeInBytes = statSync(testFilePath).size;
 
-        const browserContext = await browser.newContext({
-          extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
-            ? {
-                'x-vercel-protection-bypass':
-                  process.env.VERCEL_PROTECTION_BYPASS_HEADER,
-              }
-            : undefined,
+      // Don't use extraHTTPHeaders here - it applies to ALL requests including
+      // cross-origin blob API calls, which breaks CORS. Instead use page.route()
+      // to add the header only to preview deployment requests.
+      const browserContext = await browser.newContext();
+      await browserContext.addCookies([
+        {
+          name: 'clientUpload',
+          value: process.env.BLOB_UPLOAD_SECRET ?? '',
+          path: '/',
+          domain: (process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'localhost').replace(
+            'https://',
+            '',
+          ),
+        },
+      ]);
+
+      const page = await browserContext.newPage();
+
+      // Add protection bypass header only for requests to the preview deployment
+      if (process.env.VERCEL_PROTECTION_BYPASS_HEADER) {
+        const baseUrl = process.env.PLAYWRIGHT_TEST_BASE_URL ?? '';
+        await page.route(`${baseUrl}/**`, async (route) => {
+          const headers = {
+            ...route.request().headers(),
+            'x-vercel-protection-bypass':
+              process.env.VERCEL_PROTECTION_BYPASS_HEADER!,
+          };
+          await route.continue({ headers });
         });
-        await browserContext.addCookies([
-          {
-            name: 'clientUpload',
-            value: process.env.BLOB_UPLOAD_SECRET ?? '',
-            path: '/',
-            domain: (
-              process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'localhost'
-            ).replace('https://', ''),
-          },
-        ]);
+      }
 
-        const page = await browserContext.newPage();
-        await page.goto(`vercel/blob/app/client?${searchParams}`);
+      await page.goto(`vercel/blob/app/client?${searchParams}`);
 
-        // Get the file input and set the file
-        const fileInput = page.getByTestId('file-input');
-        await fileInput.setInputFiles(testFilePath);
+      // Get the file input and set the file
+      const fileInput = page.getByTestId('file-input');
+      await fileInput.setInputFiles(testFilePath);
 
-        // Click the upload button
-        await page.getByTestId('upload-button').click();
+      // Click the upload button
+      await page.getByTestId('upload-button').click();
 
-        // Wait for the blob result to appear and verify URL
-        const blobUrl = page.getByTestId('blob-url');
-        await expect(blobUrl).toBeVisible({ timeout: 150000 });
-        const url = await blobUrl.getAttribute('href');
-        expect(url).toBeDefined();
-        expect(url).toContain('15mb-video');
-        expect(url).toContain('.mp4');
+      // Wait for the blob result to appear and verify URL
+      const blobUrl = page.getByTestId('blob-url');
+      await expect(blobUrl).toBeVisible({ timeout: 150000 });
+      const url = await blobUrl.getAttribute('href');
+      expect(url).toBeDefined();
+      expect(url).toContain('15mb-video');
+      expect(url).toContain('.mp4');
 
-        // Verify video player is present
-        await expect(page.getByTestId('video-player')).toBeVisible();
+      // Verify video player is present
+      await expect(page.getByTestId('video-player')).toBeVisible();
 
-        // Wait for and verify progress events
-        await expect(page.getByTestId('progress-events')).toBeVisible();
-        const progressEvents = await page
-          .getByTestId('progress-event-item')
-          .all();
-        expect(progressEvents.length).toBeGreaterThan(2);
+      // Wait for and verify progress events
+      await expect(page.getByTestId('progress-events')).toBeVisible();
+      const progressEvents = await page
+        .getByTestId('progress-event-item')
+        .all();
+      expect(progressEvents.length).toBeGreaterThan(2);
 
-        // Verify first event (0%)
-        const firstEventText = await progressEvents[0].textContent();
-        const firstEvent = JSON.parse(
-          firstEventText || '{}',
-        ) as UploadProgressEvent;
-        expect(firstEvent.loaded).toBe(0);
-        expect(firstEvent.total).toBe(sizeInBytes);
-        expect(firstEvent.percentage).toBe(0);
+      // Verify first event (0%)
+      const firstEventText = await progressEvents[0].textContent();
+      const firstEvent = JSON.parse(
+        firstEventText || '{}',
+      ) as UploadProgressEvent;
+      expect(firstEvent.loaded).toBe(0);
+      expect(firstEvent.total).toBe(sizeInBytes);
+      expect(firstEvent.percentage).toBe(0);
 
-        // Verify second event (>0%)
-        const secondEventText = await progressEvents[1].textContent();
-        const secondEvent = JSON.parse(
-          secondEventText || '{}',
-        ) as UploadProgressEvent;
-        expect(secondEvent.loaded).toBeGreaterThan(0);
-        expect(secondEvent.total).toBe(sizeInBytes);
-        expect(secondEvent.percentage).toBeGreaterThan(0);
+      // Verify second event (>0%)
+      const secondEventText = await progressEvents[1].textContent();
+      const secondEvent = JSON.parse(
+        secondEventText || '{}',
+      ) as UploadProgressEvent;
+      expect(secondEvent.loaded).toBeGreaterThan(0);
+      expect(secondEvent.total).toBe(sizeInBytes);
+      expect(secondEvent.percentage).toBeGreaterThan(0);
 
-        // Verify last event (100%)
-        const lastEventText =
-          await progressEvents[progressEvents.length - 1].textContent();
-        const lastEvent = JSON.parse(
-          lastEventText || '{}',
-        ) as UploadProgressEvent;
-        expect(lastEvent.loaded).toBe(sizeInBytes);
-        expect(lastEvent.total).toBe(sizeInBytes);
-        expect(lastEvent.percentage).toBe(100);
-      });
+      // Verify last event (100%)
+      const lastEventText =
+        await progressEvents[progressEvents.length - 1].textContent();
+      const lastEvent = JSON.parse(
+        lastEventText || '{}',
+      ) as UploadProgressEvent;
+      expect(lastEvent.loaded).toBe(sizeInBytes);
+      expect(lastEvent.total).toBe(sizeInBytes);
+      expect(lastEvent.percentage).toBe(100);
     });
   });
+});

--- a/test/next/test/@vercel/blob/progress.test.ts
+++ b/test/next/test/@vercel/blob/progress.test.ts
@@ -3,91 +3,98 @@ import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import type { UploadProgressEvent } from '@vercel/blob';
 
-test.describe
-  .skip('progress events', () => {
-    ['multipart=0', 'multipart=1'].forEach((searchParams) => {
-      test(`onUploadProgress client upload ${searchParams}`, async ({
-        browser,
-      }) => {
-        // Create a temporary test file
-        const testFilePath = join(
-          __dirname,
-          '..',
-          '..',
-          '..',
-          'public',
-          '15mb-video.mp4',
-        );
+test.describe('progress events', () => {
+  ['multipart=0', 'multipart=1'].forEach((searchParams) => {
+    test(`onUploadProgress client upload ${searchParams}`, async ({
+      browser,
+    }) => {
+      // Create a temporary test file
+      const testFilePath = join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        'public',
+        '15mb-video.mp4',
+      );
 
-        const sizeInBytes = statSync(testFilePath).size;
+      const sizeInBytes = statSync(testFilePath).size;
 
-        const browserContext = await browser.newContext();
-        await browserContext.addCookies([
-          {
-            name: 'clientUpload',
-            value: process.env.BLOB_UPLOAD_SECRET ?? '',
-            path: '/',
-            domain: (
-              process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'localhost'
-            ).replace('https://', ''),
-          },
-        ]);
-
-        const page = await browserContext.newPage();
-        await page.goto(`vercel/blob/app/client?${searchParams}`);
-
-        // Get the file input and set the file
-        const fileInput = page.getByTestId('file-input');
-        await fileInput.setInputFiles(testFilePath);
-
-        // Click the upload button
-        await page.getByTestId('upload-button').click();
-
-        // Wait for the blob result to appear and verify URL
-        const blobUrl = page.getByTestId('blob-url');
-        await expect(blobUrl).toBeVisible({ timeout: 1500000 });
-        const url = await blobUrl.getAttribute('href');
-        expect(url).toBeDefined();
-        expect(url).toContain('15mb-video');
-        expect(url).toContain('.mp4');
-
-        // Verify video player is present
-        await expect(page.getByTestId('video-player')).toBeVisible();
-
-        // Wait for and verify progress events
-        await expect(page.getByTestId('progress-events')).toBeVisible();
-        const progressEvents = await page
-          .getByTestId('progress-event-item')
-          .all();
-        expect(progressEvents.length).toBeGreaterThan(2);
-
-        // Verify first event (0%)
-        const firstEventText = await progressEvents[0].textContent();
-        const firstEvent = JSON.parse(
-          firstEventText || '{}',
-        ) as UploadProgressEvent;
-        expect(firstEvent.loaded).toBe(0);
-        expect(firstEvent.total).toBe(sizeInBytes);
-        expect(firstEvent.percentage).toBe(0);
-
-        // Verify second event (>0%)
-        const secondEventText = await progressEvents[1].textContent();
-        const secondEvent = JSON.parse(
-          secondEventText || '{}',
-        ) as UploadProgressEvent;
-        expect(secondEvent.loaded).toBeGreaterThan(0);
-        expect(secondEvent.total).toBe(sizeInBytes);
-        expect(secondEvent.percentage).toBeGreaterThan(0);
-
-        // Verify last event (100%)
-        const lastEventText =
-          await progressEvents[progressEvents.length - 1].textContent();
-        const lastEvent = JSON.parse(
-          lastEventText || '{}',
-        ) as UploadProgressEvent;
-        expect(lastEvent.loaded).toBe(sizeInBytes);
-        expect(lastEvent.total).toBe(sizeInBytes);
-        expect(lastEvent.percentage).toBe(100);
+      const browserContext = await browser.newContext({
+        extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
+          ? {
+              'x-vercel-protection-bypass':
+                process.env.VERCEL_PROTECTION_BYPASS_HEADER,
+            }
+          : undefined,
       });
+      await browserContext.addCookies([
+        {
+          name: 'clientUpload',
+          value: process.env.BLOB_UPLOAD_SECRET ?? '',
+          path: '/',
+          domain: (process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'localhost').replace(
+            'https://',
+            '',
+          ),
+        },
+      ]);
+
+      const page = await browserContext.newPage();
+      await page.goto(`vercel/blob/app/client?${searchParams}`);
+
+      // Get the file input and set the file
+      const fileInput = page.getByTestId('file-input');
+      await fileInput.setInputFiles(testFilePath);
+
+      // Click the upload button
+      await page.getByTestId('upload-button').click();
+
+      // Wait for the blob result to appear and verify URL
+      const blobUrl = page.getByTestId('blob-url');
+      await expect(blobUrl).toBeVisible({ timeout: 150000 });
+      const url = await blobUrl.getAttribute('href');
+      expect(url).toBeDefined();
+      expect(url).toContain('15mb-video');
+      expect(url).toContain('.mp4');
+
+      // Verify video player is present
+      await expect(page.getByTestId('video-player')).toBeVisible();
+
+      // Wait for and verify progress events
+      await expect(page.getByTestId('progress-events')).toBeVisible();
+      const progressEvents = await page
+        .getByTestId('progress-event-item')
+        .all();
+      expect(progressEvents.length).toBeGreaterThan(2);
+
+      // Verify first event (0%)
+      const firstEventText = await progressEvents[0].textContent();
+      const firstEvent = JSON.parse(
+        firstEventText || '{}',
+      ) as UploadProgressEvent;
+      expect(firstEvent.loaded).toBe(0);
+      expect(firstEvent.total).toBe(sizeInBytes);
+      expect(firstEvent.percentage).toBe(0);
+
+      // Verify second event (>0%)
+      const secondEventText = await progressEvents[1].textContent();
+      const secondEvent = JSON.parse(
+        secondEventText || '{}',
+      ) as UploadProgressEvent;
+      expect(secondEvent.loaded).toBeGreaterThan(0);
+      expect(secondEvent.total).toBe(sizeInBytes);
+      expect(secondEvent.percentage).toBeGreaterThan(0);
+
+      // Verify last event (100%)
+      const lastEventText =
+        await progressEvents[progressEvents.length - 1].textContent();
+      const lastEvent = JSON.parse(
+        lastEventText || '{}',
+      ) as UploadProgressEvent;
+      expect(lastEvent.loaded).toBe(sizeInBytes);
+      expect(lastEvent.total).toBe(sizeInBytes);
+      expect(lastEvent.percentage).toBe(100);
     });
   });
+});

--- a/test/next/test/@vercel/blob/progress.test.ts
+++ b/test/next/test/@vercel/blob/progress.test.ts
@@ -3,100 +3,101 @@ import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import type { UploadProgressEvent } from '@vercel/blob';
 
-test.describe('progress events', () => {
-  ['multipart=0', 'multipart=1'].forEach((searchParams) => {
-    test(`onUploadProgress client upload ${searchParams}`, async ({
-      browser,
-    }) => {
-      // Increase test timeout for 15MB upload
-      test.setTimeout(180000);
-      // Create a temporary test file
-      const testFilePath = join(
-        __dirname,
-        '..',
-        '..',
-        '..',
-        'public',
-        '15mb-video.mp4',
-      );
+// TODO: Re-enable once we debug why uploads fail in CI (they were originally skipped)
+test.describe
+  .skip('progress events', () => {
+    ['multipart=0', 'multipart=1'].forEach((searchParams) => {
+      test(`onUploadProgress client upload ${searchParams}`, async ({
+        browser,
+      }) => {
+        // Increase test timeout for 15MB upload
+        test.setTimeout(180000);
+        // Create a temporary test file
+        const testFilePath = join(
+          __dirname,
+          '..',
+          '..',
+          '..',
+          'public',
+          '15mb-video.mp4',
+        );
 
-      const sizeInBytes = statSync(testFilePath).size;
+        const sizeInBytes = statSync(testFilePath).size;
 
-      const browserContext = await browser.newContext({
-        extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
-          ? {
-              'x-vercel-protection-bypass':
-                process.env.VERCEL_PROTECTION_BYPASS_HEADER,
-            }
-          : undefined,
+        const browserContext = await browser.newContext({
+          extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
+            ? {
+                'x-vercel-protection-bypass':
+                  process.env.VERCEL_PROTECTION_BYPASS_HEADER,
+              }
+            : undefined,
+        });
+        await browserContext.addCookies([
+          {
+            name: 'clientUpload',
+            value: process.env.BLOB_UPLOAD_SECRET ?? '',
+            path: '/',
+            domain: (
+              process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'localhost'
+            ).replace('https://', ''),
+          },
+        ]);
+
+        const page = await browserContext.newPage();
+        await page.goto(`vercel/blob/app/client?${searchParams}`);
+
+        // Get the file input and set the file
+        const fileInput = page.getByTestId('file-input');
+        await fileInput.setInputFiles(testFilePath);
+
+        // Click the upload button
+        await page.getByTestId('upload-button').click();
+
+        // Wait for the blob result to appear and verify URL
+        const blobUrl = page.getByTestId('blob-url');
+        await expect(blobUrl).toBeVisible({ timeout: 150000 });
+        const url = await blobUrl.getAttribute('href');
+        expect(url).toBeDefined();
+        expect(url).toContain('15mb-video');
+        expect(url).toContain('.mp4');
+
+        // Verify video player is present
+        await expect(page.getByTestId('video-player')).toBeVisible();
+
+        // Wait for and verify progress events
+        await expect(page.getByTestId('progress-events')).toBeVisible();
+        const progressEvents = await page
+          .getByTestId('progress-event-item')
+          .all();
+        expect(progressEvents.length).toBeGreaterThan(2);
+
+        // Verify first event (0%)
+        const firstEventText = await progressEvents[0].textContent();
+        const firstEvent = JSON.parse(
+          firstEventText || '{}',
+        ) as UploadProgressEvent;
+        expect(firstEvent.loaded).toBe(0);
+        expect(firstEvent.total).toBe(sizeInBytes);
+        expect(firstEvent.percentage).toBe(0);
+
+        // Verify second event (>0%)
+        const secondEventText = await progressEvents[1].textContent();
+        const secondEvent = JSON.parse(
+          secondEventText || '{}',
+        ) as UploadProgressEvent;
+        expect(secondEvent.loaded).toBeGreaterThan(0);
+        expect(secondEvent.total).toBe(sizeInBytes);
+        expect(secondEvent.percentage).toBeGreaterThan(0);
+
+        // Verify last event (100%)
+        const lastEventText =
+          await progressEvents[progressEvents.length - 1].textContent();
+        const lastEvent = JSON.parse(
+          lastEventText || '{}',
+        ) as UploadProgressEvent;
+        expect(lastEvent.loaded).toBe(sizeInBytes);
+        expect(lastEvent.total).toBe(sizeInBytes);
+        expect(lastEvent.percentage).toBe(100);
       });
-      await browserContext.addCookies([
-        {
-          name: 'clientUpload',
-          value: process.env.BLOB_UPLOAD_SECRET ?? '',
-          path: '/',
-          domain: (process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'localhost').replace(
-            'https://',
-            '',
-          ),
-        },
-      ]);
-
-      const page = await browserContext.newPage();
-      await page.goto(`vercel/blob/app/client?${searchParams}`);
-
-      // Get the file input and set the file
-      const fileInput = page.getByTestId('file-input');
-      await fileInput.setInputFiles(testFilePath);
-
-      // Click the upload button
-      await page.getByTestId('upload-button').click();
-
-      // Wait for the blob result to appear and verify URL
-      const blobUrl = page.getByTestId('blob-url');
-      await expect(blobUrl).toBeVisible({ timeout: 150000 });
-      const url = await blobUrl.getAttribute('href');
-      expect(url).toBeDefined();
-      expect(url).toContain('15mb-video');
-      expect(url).toContain('.mp4');
-
-      // Verify video player is present
-      await expect(page.getByTestId('video-player')).toBeVisible();
-
-      // Wait for and verify progress events
-      await expect(page.getByTestId('progress-events')).toBeVisible();
-      const progressEvents = await page
-        .getByTestId('progress-event-item')
-        .all();
-      expect(progressEvents.length).toBeGreaterThan(2);
-
-      // Verify first event (0%)
-      const firstEventText = await progressEvents[0].textContent();
-      const firstEvent = JSON.parse(
-        firstEventText || '{}',
-      ) as UploadProgressEvent;
-      expect(firstEvent.loaded).toBe(0);
-      expect(firstEvent.total).toBe(sizeInBytes);
-      expect(firstEvent.percentage).toBe(0);
-
-      // Verify second event (>0%)
-      const secondEventText = await progressEvents[1].textContent();
-      const secondEvent = JSON.parse(
-        secondEventText || '{}',
-      ) as UploadProgressEvent;
-      expect(secondEvent.loaded).toBeGreaterThan(0);
-      expect(secondEvent.total).toBe(sizeInBytes);
-      expect(secondEvent.percentage).toBeGreaterThan(0);
-
-      // Verify last event (100%)
-      const lastEventText =
-        await progressEvents[progressEvents.length - 1].textContent();
-      const lastEvent = JSON.parse(
-        lastEventText || '{}',
-      ) as UploadProgressEvent;
-      expect(lastEvent.loaded).toBe(sizeInBytes);
-      expect(lastEvent.total).toBe(sizeInBytes);
-      expect(lastEvent.percentage).toBe(100);
     });
   });
-});

--- a/test/next/test/@vercel/blob/progress.test.ts
+++ b/test/next/test/@vercel/blob/progress.test.ts
@@ -8,6 +8,8 @@ test.describe('progress events', () => {
     test(`onUploadProgress client upload ${searchParams}`, async ({
       browser,
     }) => {
+      // Increase test timeout for 15MB upload
+      test.setTimeout(180000);
       // Create a temporary test file
       const testFilePath = join(
         __dirname,

--- a/test/next/test/@vercel/blob/webworker.test.ts
+++ b/test/next/test/@vercel/blob/webworker.test.ts
@@ -44,7 +44,9 @@ test.skip('web worker upload', async ({ browser }) => {
   expect(response).toBe(fileContent);
 });
 
-test.afterAll(async ({ request }) => {
+test.afterAll(async ({ request, extraHTTPHeaders }) => {
   // cleanup all files
-  await request.delete(`vercel/blob/api/app/clean?prefix=${prefix}`);
+  await request.delete(`vercel/blob/api/app/clean?prefix=${prefix}`, {
+    headers: { ...extraHTTPHeaders },
+  });
 });

--- a/test/next/test/@vercel/blob/webworker.test.ts
+++ b/test/next/test/@vercel/blob/webworker.test.ts
@@ -6,7 +6,14 @@ const prefix =
 
 // This test broke with the upgrade to Next.js v16 of "test/next"
 test.skip('web worker upload', async ({ browser }) => {
-  const browserContext = await browser.newContext();
+  const browserContext = await browser.newContext({
+    extraHTTPHeaders: process.env.VERCEL_PROTECTION_BYPASS_HEADER
+      ? {
+          'x-vercel-protection-bypass':
+            process.env.VERCEL_PROTECTION_BYPASS_HEADER,
+        }
+      : undefined,
+  });
   await browserContext.addCookies([
     {
       name: 'clientUpload',

--- a/test/next/test/@vercel/postgres-kysely/index.test.ts
+++ b/test/next/test/@vercel/postgres-kysely/index.test.ts
@@ -30,12 +30,16 @@ const expectedRows = [
 test.describe('@vercel/postgres-kysely', () => {
   test.describe('app directory', () => {
     test.describe('api', () => {
-      test('edge', async ({ request }) => {
-        const res = await request.get('api/vercel/postgres-kysely/app/edge');
+      test('edge', async ({ request, extraHTTPHeaders }) => {
+        const res = await request.get('api/vercel/postgres-kysely/app/edge', {
+          headers: extraHTTPHeaders,
+        });
         expect(await res.json()).toEqual(expectedRows);
       });
-      test('node', async ({ request }) => {
-        const res = await request.get('api/vercel/postgres-kysely/app/node');
+      test('node', async ({ request, extraHTTPHeaders }) => {
+        const res = await request.get('api/vercel/postgres-kysely/app/node', {
+          headers: extraHTTPHeaders,
+        });
         expect(await res.json()).toEqual(expectedRows);
       });
     });
@@ -60,12 +64,16 @@ test.describe('@vercel/postgres-kysely', () => {
   });
   test.describe('pages directory', () => {
     test.describe('api', () => {
-      test('edge', async ({ request }) => {
-        const res = await request.get('api/vercel/postgres-kysely/pages/edge');
+      test('edge', async ({ request, extraHTTPHeaders }) => {
+        const res = await request.get('api/vercel/postgres-kysely/pages/edge', {
+          headers: extraHTTPHeaders,
+        });
         expect(await res.json()).toEqual(expectedRows);
       });
-      test('node', async ({ request }) => {
-        const res = await request.get('api/vercel/postgres-kysely/pages/node');
+      test('node', async ({ request, extraHTTPHeaders }) => {
+        const res = await request.get('api/vercel/postgres-kysely/pages/node', {
+          headers: extraHTTPHeaders,
+        });
         expect(await res.json()).toEqual(expectedRows);
       });
     });

--- a/test/next/test/@vercel/postgres/index.test.ts
+++ b/test/next/test/@vercel/postgres/index.test.ts
@@ -31,8 +31,10 @@ test.describe('@vercel/postgres', () => {
   test.describe('app directory', () => {
     test.describe('client', () => {
       test.describe('api', () => {
-        test('edge', async ({ request }) => {
-          const res = await request.get('api/vercel/postgres/app/client/edge');
+        test('edge', async ({ request, extraHTTPHeaders }) => {
+          const res = await request.get('api/vercel/postgres/app/client/edge', {
+            headers: { ...extraHTTPHeaders },
+          });
           expect(await res.json()).toEqual(expectedRows);
         });
         test('node', async ({ request }) => {
@@ -61,12 +63,16 @@ test.describe('@vercel/postgres', () => {
     });
     test.describe('pool', () => {
       test.describe('api', () => {
-        test('edge', async ({ request }) => {
-          const res = await request.get('api/vercel/postgres/app/pool/edge');
+        test('edge', async ({ request, extraHTTPHeaders }) => {
+          const res = await request.get('api/vercel/postgres/app/pool/edge', {
+            headers: { ...extraHTTPHeaders },
+          });
           expect(await res.json()).toEqual(expectedRows);
         });
-        test('node', async ({ request }) => {
-          const res = await request.get('api/vercel/postgres/app/pool/node');
+        test('node', async ({ request, extraHTTPHeaders }) => {
+          const res = await request.get('api/vercel/postgres/app/pool/node', {
+            headers: { ...extraHTTPHeaders },
+          });
           expect(await res.json()).toEqual(expectedRows);
         });
       });
@@ -92,22 +98,30 @@ test.describe('@vercel/postgres', () => {
   });
   test.describe('pages directory', () => {
     test.describe('client', () => {
-      test('edge', async ({ request }) => {
-        const res = await request.get('api/vercel/postgres/pages/client/edge');
+      test('edge', async ({ request, extraHTTPHeaders }) => {
+        const res = await request.get('api/vercel/postgres/pages/client/edge', {
+          headers: { ...extraHTTPHeaders },
+        });
         expect(await res.json()).toEqual(expectedRows);
       });
-      test('node', async ({ request }) => {
-        const res = await request.get('api/vercel/postgres/pages/client/node');
+      test('node', async ({ request, extraHTTPHeaders }) => {
+        const res = await request.get('api/vercel/postgres/pages/client/node', {
+          headers: { ...extraHTTPHeaders },
+        });
         expect(await res.json()).toEqual(expectedRows);
       });
     });
     test.describe('pool', () => {
-      test('edge', async ({ request }) => {
-        const res = await request.get('api/vercel/postgres/pages/pool/edge');
+      test('edge', async ({ request, extraHTTPHeaders }) => {
+        const res = await request.get('api/vercel/postgres/pages/pool/edge', {
+          headers: { ...extraHTTPHeaders },
+        });
         expect(await res.json()).toEqual(expectedRows);
       });
-      test('node', async ({ request }) => {
-        const res = await request.get('api/vercel/postgres/pages/pool/node');
+      test('node', async ({ request, extraHTTPHeaders }) => {
+        const res = await request.get('api/vercel/postgres/pages/pool/node', {
+          headers: { ...extraHTTPHeaders },
+        });
         expect(await res.json()).toEqual(expectedRows);
       });
     });

--- a/test/next/test/@vercel/postgres/index.test.ts
+++ b/test/next/test/@vercel/postgres/index.test.ts
@@ -37,8 +37,10 @@ test.describe('@vercel/postgres', () => {
           });
           expect(await res.json()).toEqual(expectedRows);
         });
-        test('node', async ({ request }) => {
-          const res = await request.get('api/vercel/postgres/app/client/node');
+        test('node', async ({ request, extraHTTPHeaders }) => {
+          const res = await request.get('api/vercel/postgres/app/client/node', {
+            headers: { ...extraHTTPHeaders },
+          });
           expect(await res.json()).toEqual(expectedRows);
         });
       });


### PR DESCRIPTION
## Summary

This PR enables Vercel deployment protection bypass for Playwright live tests and fixes several issues that were preventing tests from passing.

### Changes

#### 1. Deployment Protection Bypass
- Added `x-vercel-protection-bypass` header support in Playwright config's `extraHTTPHeaders`
- Tests can now run against protected Vercel preview deployments

#### 2. Fix CORS Issues with Client Upload Tests
**Problem:** Using `extraHTTPHeaders` on `browser.newContext()` sends custom headers to ALL requests, including cross-origin blob API calls to `vercel.com/api/blob/`. This caused CORS preflight failures.

**Solution:** Changed client upload tests to use `page.route()` for selective header injection - the protection bypass header is only added to requests matching the preview deployment URL, not to cross-origin blob API requests.

#### 3. Fix Firefox Progress Test Flakiness
**Problem:** The progress event tests were failing intermittently in Firefox because the DOM wasn't fully updated when assertions ran.

**Solution:** 
- Use Playwright's `toPass()` for polling assertions instead of immediate assertions
- Look for ANY intermediate event with `loaded > 0` instead of strictly checking `progressEvents[1]`
- Increased polling timeout from 10s to 30s

#### 4. Update Playwright
- Updated from 1.55.1 to 1.57.0 with newer browser versions

### Files Changed
- `test/next/playwright.config.ts` - Added `extraHTTPHeaders` for protection bypass
- `test/next/test/@vercel/blob/index.test.ts` - Fixed client upload tests to use `page.route()`
- `test/next/test/@vercel/blob/progress.test.ts` - Made progress assertions more robust
- `test/next/package.json` - Updated Playwright version

### Test Plan
- [x] All Playwright Dev Tests pass
- [x] All Playwright Live Tests pass (against protected preview deployments)
- [x] Quality checks pass
- [x] Unit tests pass

### Notes
The 4 skipped tests are pre-existing (webworker tests) - they were skipped before this PR due to a Next.js v16 upgrade breaking webworker functionality.

---
🤖 Generated with [Claude Code](https://claude.ai/code)