### PR TITLE
update readme to add deprecated message for postgres/kv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # [Vercel Storage](https://vercel.com/docs/storage)
 
-- `@vercel/postgres` Vercel Postgres database client — [Documentation](https://vercel.com/docs/storage/vercel-postgres) | [Source](./packages/postgres)
-- `@vercel/kv` Durable Redis-compatible Key Value store — [Documentation](https://vercel.com/docs/storage/vercel-kv) | [Source](./packages/kv)
-- `@vercel/edge-config` Ultra-low latency data at the edge — [Documentation](https://vercel.com/docs/storage/edge-config) | [Source](./packages/edge-config)
-- `@vercel/blob` Fast object storage — [Documentation](https://vercel.com/docs/storage/vercel-blob) | [Source](./packages/blob)
-- `@vercel/postgres-kysely` A `@vercel/postgres` wrapper for the [kysely ORM](https://github.com/kysely-org/kysely) — [Documentation](./packages/postgres-kysely) | [Source](./packages/postgres-kysely)
+## Packages
+
+- `@Vercel/edge-config` Ultra-low latency data at the edge — [Documentation](https://vercel.com/docs/storage/edge-config) | [Source](./packages/edge-config)
+- `@Vercel/blob` Fast object storage — [Documentation](https://vercel.com/docs/storage/vercel-blob) | [Source](./packages/blob)
+
+## Deprecated Packages
+
+> **Note:** Vercel Postgres and Vercel KV products are now sunset. You can install other postgres and KV storage solutions from the [Vercel Marketplace](https://vercel.com/marketplace) as native integrations to your Vercel project.
+
+- `@Vercel/postgres` Vercel Postgres database client — [Documentation](https://vercel.com/docs/storage/vercel-postgres) | [Source](./packages/postgres)
+- `@Vercel/kv` Durable Redis-compatible Key Value store — [Documentation](https://vercel.com/docs/storage/vercel-kv) | [Source](./packages/kv)
+- `@Vercel/postgres-kysely` A `@Vercel/postgres` wrapper for the [kysely ORM](https://github.com/kysely-org/kysely) — [Documentation](./packages/postgres-kysely) | [Source](./packages/postgres-kysely)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Packages
 
-- `@Vercel/edge-config` Ultra-low latency data at the edge — [Documentation](https://vercel.com/docs/storage/edge-config) | [Source](./packages/edge-config)
-- `@Vercel/blob` Fast object storage — [Documentation](https://vercel.com/docs/storage/vercel-blob) | [Source](./packages/blob)
+- `@vercel/edge-config` Ultra-low latency data at the edge — [Documentation](https://vercel.com/docs/storage/edge-config) | [Source](./packages/edge-config)
+- `@vercel/blob` Fast object storage — [Documentation](https://vercel.com/docs/storage/vercel-blob) | [Source](./packages/blob)
 
 ## Deprecated Packages
 
 > **Note:** Vercel Postgres and Vercel KV products are now sunset. You can install other postgres and KV storage solutions from the [Vercel Marketplace](https://vercel.com/marketplace) as native integrations to your Vercel project.
 
-- `@Vercel/postgres` Vercel Postgres database client — [Documentation](https://vercel.com/docs/storage/vercel-postgres) | [Source](./packages/postgres)
-- `@Vercel/kv` Durable Redis-compatible Key Value store — [Documentation](https://vercel.com/docs/storage/vercel-kv) | [Source](./packages/kv)
-- `@Vercel/postgres-kysely` A `@Vercel/postgres` wrapper for the [kysely ORM](https://github.com/kysely-org/kysely) — [Documentation](./packages/postgres-kysely) | [Source](./packages/postgres-kysely)
+- `@vercel/postgres` Vercel Postgres database client — [Documentation](https://vercel.com/docs/storage/vercel-postgres) | [Source](./packages/postgres)
+- `@vercel/kv` Durable Redis-compatible Key Value store — [Documentation](https://vercel.com/docs/storage/vercel-kv) | [Source](./packages/kv)
+- `@vercel/postgres-kysely` A `@vercel/postgres` wrapper for the [kysely ORM](https://github.com/kysely-org/kysely) — [Documentation](./packages/postgres-kysely) | [Source](./packages/postgres-kysely)


### PR DESCRIPTION
Add deprecated message in our ReadMe for postgres and kv packages. Will check with npm library owner to mark them deprecated on npm as well.