### PR TITLE
[blob] feat: add useCache option to bypass CDN cache

### DIFF
--- a/packages/blob/src/get.ts
+++ b/packages/blob/src/get.ts
@@ -15,10 +15,12 @@ export interface GetCommandOptions extends BlobCommandOptions {
   access: BlobAccessType;
   /**
    * Whether to use the content-cache layer when fetching the blob.
-   * When false, appends ?cache=0 to bypass the cache and fetch directly.
+   * When false, bypasses the cache and fetches directly from storage.
+   * Only effective for private blobs (ignored for public blobs).
    * @defaultValue true
    */
   useCache?: boolean;
+  /**
    * Advanced: Additional headers to include in the fetch request.
    * You probably don't need this. The authorization header is automatically set.
    */
@@ -96,10 +98,11 @@ function constructBlobUrl(storeId: string, pathname: string): string {
  *
  * @example
  * ```ts
- * const { stream, headers, blob } = await get('user123/love-letter.txt', { access: 'private' });
- * // stream is the ReadableStream from fetch() - no automatic buffering
- * // headers is the raw Headers object from the fetch response
- * // blob is the metadata object { url, pathname, contentType, size }
+ * // Basic usage
+ * const { stream, headers, blob } = await get('user123/avatar.png', { access: 'private' });
+ *
+ * // Bypass cache for private blobs (always fetch fresh from storage)
+ * const { stream, headers, blob } = await get('user123/data.json', { access: 'private', useCache: false });
  * ```
  *
  * Detailed documentation can be found here: https://vercel.com/docs/vercel-blob/using-blob-sdk
@@ -107,6 +110,7 @@ function constructBlobUrl(storeId: string, pathname: string): string {
  * @param urlOrPathname - The URL or pathname of the blob to fetch.
  * @param options - Configuration options including:
  *   - access - (Required) Must be 'public' or 'private'. Determines the access level of the blob.
+ *   - useCache - (Optional) When false, bypasses the cache and fetches directly from storage. Only effective for private blobs. Defaults to true.
  *   - token - (Optional) A string specifying the token to use when making requests. It defaults to process.env.BLOB_READ_WRITE_TOKEN when deployed on Vercel.
  *   - abortSignal - (Optional) AbortSignal to cancel the operation.
  *   - headers - (Optional, advanced) Additional headers to include in the fetch request. You probably don't need this.

--- a/packages/blob/src/get.ts
+++ b/packages/blob/src/get.ts
@@ -1,4 +1,3 @@
-import { fetch } from 'undici';
 import type { HeadBlobResult } from './head';
 import type { BlobAccessType, BlobCommandOptions } from './helpers';
 import { BlobError, getTokenFromOptionsOrEnv } from './helpers';

--- a/packages/blob/src/get.ts
+++ b/packages/blob/src/get.ts
@@ -13,8 +13,8 @@ export interface GetCommandOptions extends BlobCommandOptions {
    */
   access: BlobAccessType;
   /**
-   * Whether to use the content-cache layer when fetching the blob.
-   * When false, bypasses the cache and fetches directly from storage.
+   * Whether to allow the blob to be served from edge cache.
+   * When false, fetches directly from origin storage.
    * Only effective for private blobs (ignored for public blobs).
    * @defaultValue true
    */
@@ -109,7 +109,7 @@ function constructBlobUrl(storeId: string, pathname: string): string {
  * @param urlOrPathname - The URL or pathname of the blob to fetch.
  * @param options - Configuration options including:
  *   - access - (Required) Must be 'public' or 'private'. Determines the access level of the blob.
- *   - useCache - (Optional) When false, bypasses the cache and fetches directly from storage. Only effective for private blobs. Defaults to true.
+ *   - useCache - (Optional) When false, fetches directly from origin storage instead of edge cache. Only effective for private blobs. Defaults to true.
  *   - token - (Optional) A string specifying the token to use when making requests. It defaults to process.env.BLOB_READ_WRITE_TOKEN when deployed on Vercel.
  *   - abortSignal - (Optional) AbortSignal to cancel the operation.
  *   - headers - (Optional, advanced) Additional headers to include in the fetch request. You probably don't need this.

--- a/packages/blob/src/get.ts
+++ b/packages/blob/src/get.ts
@@ -13,7 +13,7 @@ export interface GetCommandOptions extends BlobCommandOptions {
    */
   access: BlobAccessType;
   /**
-   * Whether to allow the blob to be served from edge cache.
+   * Whether to allow the blob to be served from CDN cache.
    * When false, fetches directly from origin storage.
    * Only effective for private blobs (ignored for public blobs).
    * @defaultValue true
@@ -109,7 +109,7 @@ function constructBlobUrl(storeId: string, pathname: string): string {
  * @param urlOrPathname - The URL or pathname of the blob to fetch.
  * @param options - Configuration options including:
  *   - access - (Required) Must be 'public' or 'private'. Determines the access level of the blob.
- *   - useCache - (Optional) When false, fetches directly from origin storage instead of edge cache. Only effective for private blobs. Defaults to true.
+ *   - useCache - (Optional) When false, fetches directly from origin storage instead of CDN cache. Only effective for private blobs. Defaults to true.
  *   - token - (Optional) A string specifying the token to use when making requests. It defaults to process.env.BLOB_READ_WRITE_TOKEN when deployed on Vercel.
  *   - abortSignal - (Optional) AbortSignal to cancel the operation.
  *   - headers - (Optional, advanced) Additional headers to include in the fetch request. You probably don't need this.


### PR DESCRIPTION
## Summary

Adds a `useCache` option to `blob.get()` that controls whether to fetch from CDN cache or directly from origin storage:

- `useCache: true` (default) - allows blob to be served from CDN cache
- `useCache: false` - fetches directly from origin storage

**Note:** Only effective for private blobs. Public blobs always use CDN cache.

## Why

This is useful when you need the latest version of a blob immediately after an update, bypassing any cached responses.

## Usage

```typescript
const { stream, blob } = await get('my-file.txt', {
  access: 'private',
  useCache: false, // fetch directly from origin
});
```

## Test plan

- [x] Added tests for `useCache: false` appending `?cache=0`
- [x] Added tests for `useCache: true` and omitted not appending query param
- [x] Added tests verifying returned `downloadUrl` doesn't include `cache=0`
- [x] All SDK tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)