### PR TITLE
feat(blob): add ifMatch option to del() for conditional deletes

### DIFF
--- a/.changeset/add-ifmatch-to-del.md
+++ b/.changeset/add-ifmatch-to-del.md
@@ -1,0 +1,5 @@
+---
+'@vercel/blob': minor
+---
+
+Add `ifMatch` option to `del()` for conditional deletes (optimistic concurrency control). Only works for single-URL deletes.

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -265,6 +265,54 @@ describe('blob client', () => {
         ),
       );
     });
+
+    it('should send x-if-match header when ifMatch option is provided', async () => {
+      let headers: Record<string, string> = {};
+      mockClient
+        .intercept({
+          path: () => true,
+          method: 'POST',
+        })
+        .reply(200, (req) => {
+          headers = req.headers as Record<string, string>;
+          return null;
+        });
+
+      await del(`${BLOB_STORE_BASE_URL}/foo-id.txt`, {
+        ifMatch: '"abc123"',
+      });
+
+      expect(headers['x-if-match']).toEqual('"abc123"');
+    });
+
+    it('should throw BlobPreconditionFailedError on 412 response', async () => {
+      mockClient
+        .intercept({
+          path: () => true,
+          method: 'POST',
+        })
+        .reply(412, { error: { code: 'precondition_failed' } });
+
+      await expect(
+        del(`${BLOB_STORE_BASE_URL}/foo-id.txt`, {
+          ifMatch: '"old-etag"',
+        }),
+      ).rejects.toThrow(BlobPreconditionFailedError);
+    });
+
+    it('should throw when ifMatch is used with multiple URLs', async () => {
+      await expect(
+        del(
+          [
+            `${BLOB_STORE_BASE_URL}/foo-id1.txt`,
+            `${BLOB_STORE_BASE_URL}/foo-id2.txt`,
+          ],
+          { ifMatch: '"abc123"' },
+        ),
+      ).rejects.toThrow(
+        'Vercel Blob: ifMatch can only be used when deleting a single URL.',
+      );
+    });
   });
 
   describe('list', () => {

--- a/packages/blob/src/index.ts
+++ b/packages/blob/src/index.ts
@@ -69,6 +69,7 @@ export const put = createPutMethod<PutCommandOptions>({
 
 //  vercelBlob.del()
 
+export type { DeleteCommandOptions } from './del';
 export { del } from './del';
 
 // vercelBlob.head()


### PR DESCRIPTION
## Summary
- Adds `ifMatch` option to `del()` for optimistic concurrency control via ETags
- When `ifMatch` is provided, the delete only succeeds if the blob's current ETag matches the expected value
- Validates that `ifMatch` can only be used with single-URL deletes (throws `BlobError` for arrays with multiple URLs)
- Sends `x-if-match` header to the API when the option is provided
- Exports the new `DeleteCommandOptions` type

## Test plan
- [x] Unit test: sends `x-if-match` header when `ifMatch` option is provided
- [x] Unit test: throws `BlobPreconditionFailedError` on 412 response
- [x] Unit test: throws when `ifMatch` is used with multiple URLs
- [x] All existing tests pass (84/84)

Companion API PR needed for server-side handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)