### PR TITLE
fix(blob): validate URL domain in get() to prevent token leakage

### DIFF
--- a/.changeset/validate-get-url-domain.md
+++ b/.changeset/validate-get-url-domain.md
@@ -1,0 +1,5 @@
+---
+'@vercel/blob': patch
+---
+
+fix: validate URL domain in `get()` to prevent sending the token to arbitrary hosts

--- a/packages/blob/src/get.ts
+++ b/packages/blob/src/get.ts
@@ -173,6 +173,18 @@ export async function get(
   if (isUrl(urlOrPathname)) {
     blobUrl = urlOrPathname;
     pathname = extractPathnameFromUrl(urlOrPathname);
+
+    try {
+      const { hostname } = new URL(blobUrl);
+      if (!hostname.endsWith('.blob.vercel-storage.com')) {
+        throw new BlobError(
+          'Invalid URL: the URL does not point to a Vercel Blob store. Use a pathname instead, see https://vercel.com/docs/vercel-blob',
+        );
+      }
+    } catch (error) {
+      if (error instanceof BlobError) throw error;
+      throw new BlobError('Invalid URL: unable to parse the provided URL');
+    }
   } else {
     // Construct the URL from the token's storeId and the pathname
     const storeId = getStoreIdFromToken(token);

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -1334,6 +1334,67 @@ describe('blob client', () => {
       );
     });
 
+    it('should throw when URL points to an external domain', async () => {
+      await expect(
+        get('https://evil.com/xss.html', { access: 'private' }),
+      ).rejects.toThrow(
+        new Error(
+          'Vercel Blob: Invalid URL: the URL does not point to a Vercel Blob store. Use a pathname instead, see https://vercel.com/docs/vercel-blob',
+        ),
+      );
+    });
+
+    it('should throw when URL points to an external domain with public access', async () => {
+      await expect(
+        get('https://evil.com/xss.html', { access: 'public' }),
+      ).rejects.toThrow(
+        new Error(
+          'Vercel Blob: Invalid URL: the URL does not point to a Vercel Blob store. Use a pathname instead, see https://vercel.com/docs/vercel-blob',
+        ),
+      );
+    });
+
+    it('should throw when URL uses subdomain spoofing', async () => {
+      await expect(
+        get('https://blob.vercel-storage.com.evil.com/f.txt', {
+          access: 'private',
+        }),
+      ).rejects.toThrow(
+        new Error(
+          'Vercel Blob: Invalid URL: the URL does not point to a Vercel Blob store. Use a pathname instead, see https://vercel.com/docs/vercel-blob',
+        ),
+      );
+    });
+
+    it('should allow valid blob store URL', async () => {
+      const mockAgent = new MockAgent();
+      mockAgent.disableNetConnect();
+      setGlobalDispatcher(mockAgent);
+      const blobStoreMock = mockAgent.get(
+        'https://storeid.public.blob.vercel-storage.com',
+      );
+
+      blobStoreMock
+        .intercept({
+          path: '/file.txt',
+          method: 'GET',
+        })
+        .reply(200, 'blob content', {
+          headers: {
+            'content-type': 'text/plain',
+            'content-length': '12',
+          },
+        });
+
+      const result = await get(
+        'https://storeId.public.blob.vercel-storage.com/file.txt',
+        { access: 'public' },
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.blob.pathname).toEqual('file.txt');
+    });
+
     describe('useCache option', () => {
       // undici normalizes hostnames to lowercase
       const BLOB_STORE_BASE_URL_LOWERCASE =


### PR DESCRIPTION
## Summary
- When `get()` receives a full URL, it now validates that the hostname ends with `.blob.vercel-storage.com` before sending the Bearer token
- Prevents leaking the blob token to arbitrary domains when user input is passed to `get()` without validation
- Rejects subdomain spoofing attempts (e.g. `blob.vercel-storage.com.evil.com`)

## Test plan
- [x] Added test: rejects external domain (private access)
- [x] Added test: rejects external domain (public access)
- [x] Added test: rejects subdomain spoofing
- [x] Added test: allows valid blob store URL
- [x] All existing blob SDK tests pass (130 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)