### PR TITLE
[@vercel/blob] Make ifMatch imply allowOverwrite, throw on contradiction

### DIFF
--- a/.changeset/ifmatch-implies-allow-overwrite.md
+++ b/.changeset/ifmatch-implies-allow-overwrite.md
@@ -1,0 +1,5 @@
+---
+'@vercel/blob': patch
+---
+
+Make `ifMatch` imply `allowOverwrite: true` on `put()`. Previously, using `ifMatch` without explicitly setting `allowOverwrite: true` would cause the server to send conflicting conditional headers to S3, resulting in 500 errors. Now the SDK implicitly enables `allowOverwrite` when `ifMatch` is set, and throws a clear error if `allowOverwrite: false` is explicitly combined with `ifMatch`.

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -1711,6 +1711,61 @@ describe('blob client', () => {
 
         expect(headers['x-if-match']).toEqual('"abc123"');
       });
+
+      it('should implicitly set x-allow-overwrite when ifMatch is provided without allowOverwrite', async () => {
+        let headers: Record<string, string> = {};
+        mockClient
+          .intercept({
+            path: () => true,
+            method: 'PUT',
+          })
+          .reply(200, (req) => {
+            headers = req.headers as Record<string, string>;
+            return mockedFileMetaWithEtag;
+          });
+
+        await put('foo.txt', 'Test Body', {
+          access: 'public',
+          ifMatch: '"abc123"',
+        });
+
+        expect(headers['x-if-match']).toEqual('"abc123"');
+        expect(headers['x-allow-overwrite']).toEqual('1');
+      });
+
+      it('should throw when ifMatch is used with allowOverwrite: false', async () => {
+        await expect(
+          put('foo.txt', 'Test Body', {
+            access: 'public',
+            ifMatch: '"abc123"',
+            allowOverwrite: false,
+          }),
+        ).rejects.toThrow(
+          'ifMatch and allowOverwrite: false are contradictory. ifMatch is used for conditional overwrites, which requires allowOverwrite to be true.',
+        );
+      });
+
+      it('should work normally when ifMatch is used with allowOverwrite: true', async () => {
+        let headers: Record<string, string> = {};
+        mockClient
+          .intercept({
+            path: () => true,
+            method: 'PUT',
+          })
+          .reply(200, (req) => {
+            headers = req.headers as Record<string, string>;
+            return mockedFileMetaWithEtag;
+          });
+
+        await put('foo.txt', 'Test Body', {
+          access: 'public',
+          ifMatch: '"abc123"',
+          allowOverwrite: true,
+        });
+
+        expect(headers['x-if-match']).toEqual('"abc123"');
+        expect(headers['x-allow-overwrite']).toEqual('1');
+      });
     });
 
     describe('head', () => {

--- a/packages/blob/src/put-helpers.ts
+++ b/packages/blob/src/put-helpers.ts
@@ -93,6 +93,27 @@ export function createPutHeaders<TOptions extends CommonPutCommandOptions>(
       : '0';
   }
 
+  // ifMatch implies allowOverwrite — updating a blob by ETag inherently requires
+  // overwriting. Throw if the user explicitly contradicts this.
+  if (allowedOptions.includes('ifMatch') && options.ifMatch) {
+    if (options.allowOverwrite === false) {
+      throw new BlobError(
+        'ifMatch and allowOverwrite: false are contradictory. ifMatch is used for conditional overwrites, which requires allowOverwrite to be true.',
+      );
+    }
+
+    headers[putOptionHeaderMap.ifMatch] = options.ifMatch;
+    // Implicitly enable allowOverwrite when ifMatch is set and allowOverwrite
+    // was not explicitly provided, to prevent the server from sending
+    // conflicting If-Match + If-None-Match headers to S3.
+    if (
+      allowedOptions.includes('allowOverwrite') &&
+      options.allowOverwrite === undefined
+    ) {
+      headers[putOptionHeaderMap.allowOverwrite] = '1';
+    }
+  }
+
   if (
     allowedOptions.includes('allowOverwrite') &&
     options.allowOverwrite !== undefined
@@ -108,10 +129,6 @@ export function createPutHeaders<TOptions extends CommonPutCommandOptions>(
   ) {
     headers[putOptionHeaderMap.cacheControlMaxAge] =
       options.cacheControlMaxAge.toString();
-  }
-
-  if (allowedOptions.includes('ifMatch') && options.ifMatch) {
-    headers[putOptionHeaderMap.ifMatch] = options.ifMatch;
   }
 
   return headers;


### PR DESCRIPTION
## Summary

Fixes the SDK-side of INC-5751. When a customer calls `put()` with `ifMatch` but without `allowOverwrite: true`, the server defaults `allowOverwrite` to `false` and sends both `If-Match` and `If-None-Match: *` to S3. S3 rejects this with 501 NotImplemented, surfaced as 500 to the customer.

- When `ifMatch` is set without `allowOverwrite`, the SDK now implicitly sends `x-allow-overwrite: 1` — because `ifMatch` (conditional update by ETag) inherently requires overwriting
- When `ifMatch` is set with `allowOverwrite: false`, the SDK throws a clear `BlobError` explaining the contradiction

Server-side fix: vercel/api#65723

## Validation

- New test: `put()` with `ifMatch` and no `allowOverwrite` sends `x-allow-overwrite: 1`
- New test: `put()` with `ifMatch` and `allowOverwrite: false` throws descriptive error
- New test: `put()` with `ifMatch` and `allowOverwrite: true` works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)