### PR TITLE
[@vercel/blob] Apply ifMatch/allowOverwrite validation to handleUpload and generateClientToken

### DIFF
--- a/.changeset/ifmatch-handle-upload.md
+++ b/.changeset/ifmatch-handle-upload.md
@@ -1,0 +1,5 @@
+---
+'@vercel/blob': patch
+---
+
+Apply `ifMatch`/`allowOverwrite` validation to `handleUpload` and `generateClientTokenFromReadWriteToken`. When `ifMatch` is set via `onBeforeGenerateToken` or direct token generation, `allowOverwrite` is now implicitly enabled. Explicitly passing `allowOverwrite: false` with `ifMatch` throws a clear error.

--- a/packages/blob/src/client.node.test.ts
+++ b/packages/blob/src/client.node.test.ts
@@ -39,6 +39,33 @@ describe('client uploads', () => {
       });
     });
 
+    it('throws when ifMatch is used with allowOverwrite: false', async () => {
+      await expect(
+        generateClientTokenFromReadWriteToken({
+          pathname: 'foo.txt',
+          token: 'vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678',
+          ifMatch: '"abc123"',
+          allowOverwrite: false,
+        }),
+      ).rejects.toThrow(
+        'ifMatch and allowOverwrite: false are contradictory. ifMatch is used for conditional overwrites, which requires allowOverwrite to be true.',
+      );
+    });
+
+    it('implicitly sets allowOverwrite when ifMatch is provided', async () => {
+      const uploadToken = await generateClientTokenFromReadWriteToken({
+        pathname: 'foo.txt',
+        token: 'vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678',
+        ifMatch: '"abc123"',
+      });
+
+      expect(getPayloadFromClientToken(uploadToken)).toMatchObject({
+        pathname: 'foo.txt',
+        ifMatch: '"abc123"',
+        allowOverwrite: true,
+      });
+    });
+
     it('accepts a tokenPayload property', async () => {
       const uploadToken = await generateClientTokenFromReadWriteToken({
         pathname: 'foo.txt',

--- a/packages/blob/src/client.node.test.ts
+++ b/packages/blob/src/client.node.test.ts
@@ -43,7 +43,8 @@ describe('client uploads', () => {
       await expect(
         generateClientTokenFromReadWriteToken({
           pathname: 'foo.txt',
-          token: 'vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678',
+          token:
+            'vercel_blob_rw_12345fakeStoreId_30FakeRandomCharacters12345678',
           ifMatch: '"abc123"',
           allowOverwrite: false,
         }),

--- a/packages/blob/src/client.ts
+++ b/packages/blob/src/client.ts
@@ -766,7 +766,10 @@ export async function generateClientTokenFromReadWriteToken({
   // Implicitly enable allowOverwrite when ifMatch is set and allowOverwrite
   // was not explicitly provided, to prevent the server from sending
   // conflicting If-Match + If-None-Match headers to S3.
-  if (argsWithoutToken.ifMatch && argsWithoutToken.allowOverwrite === undefined) {
+  if (
+    argsWithoutToken.ifMatch &&
+    argsWithoutToken.allowOverwrite === undefined
+  ) {
     argsWithoutToken.allowOverwrite = true;
   }
 

--- a/packages/blob/src/client.ts
+++ b/packages/blob/src/client.ts
@@ -755,6 +755,21 @@ export async function generateClientTokenFromReadWriteToken({
     );
   }
 
+  // ifMatch implies allowOverwrite — updating a blob by ETag inherently requires
+  // overwriting. Throw if the user explicitly contradicts this.
+  if (argsWithoutToken.ifMatch && argsWithoutToken.allowOverwrite === false) {
+    throw new BlobError(
+      'ifMatch and allowOverwrite: false are contradictory. ifMatch is used for conditional overwrites, which requires allowOverwrite to be true.',
+    );
+  }
+
+  // Implicitly enable allowOverwrite when ifMatch is set and allowOverwrite
+  // was not explicitly provided, to prevent the server from sending
+  // conflicting If-Match + If-None-Match headers to S3.
+  if (argsWithoutToken.ifMatch && argsWithoutToken.allowOverwrite === undefined) {
+    argsWithoutToken.allowOverwrite = true;
+  }
+
   const timestamp = new Date();
   timestamp.setSeconds(timestamp.getSeconds() + 30);
   const readWriteToken = getTokenFromOptionsOrEnv({ token });


### PR DESCRIPTION
## Summary

Follow-up to #1022. The same `ifMatch` + `allowOverwrite: false` contradiction can happen via `handleUpload`'s `onBeforeGenerateToken` callback or direct `generateClientTokenFromReadWriteToken` calls, since those paths embed options into the client token without going through `createPutHeaders`.

- `generateClientTokenFromReadWriteToken`: throws if `ifMatch` + `allowOverwrite: false`, implicitly sets `allowOverwrite: true` when `ifMatch` is provided without `allowOverwrite`
- Covers both `handleUpload` (which calls `generateClientTokenFromReadWriteToken` internally) and direct token generation

## Validation

- New test: `generateClientTokenFromReadWriteToken` with `ifMatch` + `allowOverwrite: false` throws
- New test: `generateClientTokenFromReadWriteToken` with `ifMatch` and no `allowOverwrite` implicitly sets `allowOverwrite: true` in token payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)