### PR TITLE
fix(blob): resolve multipart deadlock on empty streams, fix TransformStream backpressure

### DIFF
--- a/.changeset/fix-stream-deadlock.md
+++ b/.changeset/fix-stream-deadlock.md
@@ -1,0 +1,5 @@
+---
+"@vercel/blob": patch
+---
+
+Fix multipart upload hanging forever on empty streams, and fix `createChunkTransformStream` bypassing backpressure by removing incorrect `queueMicrotask` wrapping.

--- a/packages/blob/src/api.node.test.ts
+++ b/packages/blob/src/api.node.test.ts
@@ -9,7 +9,7 @@ import {
   BlobUnknownError,
   requestApi,
 } from './api';
-import { BlobError } from './helpers';
+import { BlobError, createChunkTransformStream } from './helpers';
 
 describe('api', () => {
   describe('request api', () => {
@@ -131,5 +131,76 @@ describe('api', () => {
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+describe('createChunkTransformStream', () => {
+  async function collectChunks(
+    stream: ReadableStream<Uint8Array>,
+  ): Promise<Uint8Array[]> {
+    const chunks: Uint8Array[] = [];
+    const reader = stream.getReader();
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    return chunks;
+  }
+
+  it('accumulates small chunks and emits full-sized chunks', async () => {
+    const chunkSize = 4;
+    const stream = new ReadableStream<ArrayBuffer>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]).buffer);
+        controller.enqueue(new Uint8Array([3, 4, 5, 6]).buffer);
+        controller.enqueue(new Uint8Array([7]).buffer);
+        controller.close();
+      },
+    });
+
+    const chunks = await collectChunks(
+      stream.pipeThrough(createChunkTransformStream(chunkSize)),
+    );
+
+    expect(chunks).toHaveLength(2);
+    expect(Array.from(chunks[0]!)).toEqual([1, 2, 3, 4]);
+    expect(Array.from(chunks[1]!)).toEqual([5, 6, 7]);
+  });
+
+  it('calls onProgress for each emitted chunk', async () => {
+    const chunkSize = 3;
+    const progress: number[] = [];
+    const stream = new ReadableStream<ArrayBuffer>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3, 4, 5]).buffer);
+        controller.close();
+      },
+    });
+
+    await collectChunks(
+      stream.pipeThrough(
+        createChunkTransformStream(chunkSize, (bytes) => progress.push(bytes)),
+      ),
+    );
+
+    expect(progress).toEqual([3, 2]);
+  });
+
+  it('flushes remaining bytes when stream ends', async () => {
+    const chunkSize = 10;
+    const stream = new ReadableStream<ArrayBuffer>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]).buffer);
+        controller.close();
+      },
+    });
+
+    const chunks = await collectChunks(
+      stream.pipeThrough(createChunkTransformStream(chunkSize)),
+    );
+
+    expect(chunks).toHaveLength(1);
+    expect(Array.from(chunks[0]!)).toEqual([1, 2, 3]);
   });
 });

--- a/packages/blob/src/helpers.ts
+++ b/packages/blob/src/helpers.ts
@@ -261,31 +261,27 @@ export const createChunkTransformStream = (
 
   return new TransformStream<ArrayBuffer, Uint8Array>({
     transform(chunk, controller) {
-      queueMicrotask(() => {
-        // Combine the new chunk with any leftover data
-        const newBuffer = new Uint8Array(buffer.length + chunk.byteLength);
-        newBuffer.set(buffer);
-        newBuffer.set(new Uint8Array(chunk), buffer.length);
-        buffer = newBuffer;
+      // Combine the new chunk with any leftover data
+      const newBuffer = new Uint8Array(buffer.length + chunk.byteLength);
+      newBuffer.set(buffer);
+      newBuffer.set(new Uint8Array(chunk), buffer.length);
+      buffer = newBuffer;
 
-        // Output complete chunks
-        while (buffer.length >= chunkSize) {
-          const newChunk = buffer.slice(0, chunkSize);
-          controller.enqueue(newChunk);
-          onProgress?.(newChunk.byteLength);
-          buffer = buffer.slice(chunkSize);
-        }
-      });
+      // Output complete chunks
+      while (buffer.length >= chunkSize) {
+        const newChunk = buffer.slice(0, chunkSize);
+        controller.enqueue(newChunk);
+        onProgress?.(newChunk.byteLength);
+        buffer = buffer.slice(chunkSize);
+      }
     },
 
     flush(controller) {
-      queueMicrotask(() => {
-        // Send any remaining data
-        if (buffer.length > 0) {
-          controller.enqueue(buffer);
-          onProgress?.(buffer.byteLength);
-        }
-      });
+      // Send any remaining data
+      if (buffer.length > 0) {
+        controller.enqueue(buffer);
+        onProgress?.(buffer.byteLength);
+      }
     },
   });
 };

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -753,6 +753,33 @@ describe('blob client', () => {
       );
     });
 
+    it('resolves (does not hang) when multipart body is an empty ReadableStream', async () => {
+      const emptyStream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+
+      // createMultipartUpload
+      mockClient
+        .intercept({ path: () => true, method: 'POST' })
+        .reply(200, { uploadId: 'upload-123', key: 'foo.txt' });
+
+      // completeMultipartUpload (called with 0 parts for an empty stream)
+      mockClient.intercept({ path: () => true, method: 'POST' }).reply(200, {
+        url: `${BLOB_STORE_BASE_URL}/foo.txt`,
+        downloadUrl: `${BLOB_STORE_BASE_URL}/foo.txt?download=1`,
+        pathname: 'foo.txt',
+        contentType: 'text/plain',
+        contentDisposition: 'attachment; filename="foo.txt"',
+        etag: '"empty"',
+      });
+
+      await expect(
+        put('foo.txt', emptyStream, { access: 'public', multipart: true }),
+      ).resolves.toMatchObject({ pathname: 'foo.txt' });
+    });
+
     const table: [string, (signal: AbortSignal) => Promise<unknown>][] = [
       [
         'put',

--- a/packages/blob/src/multipart/upload.ts
+++ b/packages/blob/src/multipart/upload.ts
@@ -245,6 +245,11 @@ export function uploadAllParts({
               });
 
               sendParts();
+            } else if (activeUploads === 0) {
+              // Stream was empty or ended exactly on a part boundary with no
+              // in-flight uploads. Nothing will call resolve() later, so do it here.
+              reader.releaseLock();
+              resolve(completedParts);
             }
             reading = false;
             return;

--- a/test/next/src/app/vercel/blob/api/app/empty-stream-multipart/route.ts
+++ b/test/next/src/app/vercel/blob/api/app/empty-stream-multipart/route.ts
@@ -1,0 +1,32 @@
+import * as vercelBlob from '@vercel/blob';
+import { NextResponse } from 'next/server';
+import { validateUploadToken } from '../../../validate-upload-token';
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const { searchParams } = new URL(request.url);
+  const pathname = searchParams.get('filename');
+
+  if (pathname === null) {
+    return NextResponse.json({ message: 'Missing filename' }, { status: 400 });
+  }
+
+  if (!validateUploadToken(request)) {
+    return NextResponse.json({ message: 'Not authorized' }, { status: 401 });
+  }
+
+  // Multipart upload with an empty ReadableStream — this used to deadlock
+  // because uploadAllParts never called resolve() when the stream was empty.
+  const emptyStream = new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  });
+
+  const blob = await vercelBlob.put(pathname, emptyStream, {
+    access: 'public',
+    multipart: true,
+    addRandomSuffix: true,
+  });
+
+  return NextResponse.json(blob);
+}

--- a/test/next/test/@vercel/blob/index.test.ts
+++ b/test/next/test/@vercel/blob/index.test.ts
@@ -37,6 +37,27 @@ test.describe('@vercel/blob', () => {
     });
   });
 
+  test.describe('empty stream multipart', () => {
+    test('does not deadlock on empty ReadableStream with multipart: true', async ({
+      request,
+      extraHTTPHeaders,
+    }) => {
+      const res = await request.post(
+        `vercel/blob/api/app/empty-stream-multipart?filename=${prefix}/empty-stream.bin`,
+        {
+          headers: {
+            cookie: `clientUpload=${process.env.BLOB_UPLOAD_SECRET ?? ''}`,
+            ...extraHTTPHeaders,
+          },
+          timeout: 15000, // Should resolve fast, not deadlock
+        },
+      );
+      // The upload resolves (no deadlock). The server may reject the empty
+      // multipart upload, but the important thing is it doesn't hang.
+      expect(res.status()).toBeLessThan(500);
+    });
+  });
+
   test.describe('page', () => {
     test('serverless', async ({ page }) => {
       await page.goto(`vercel/pages/blob?filename=${prefix}/test-page.txt`);


### PR DESCRIPTION
## Summary

### Fix 1 — `uploadAllParts` hangs forever on empty `ReadableStream` (fixes #881)

`resolve()` was only called inside `sendPart()`. For an empty stream (or a stream that ends exactly on a part boundary with no in-flight uploads), `sendPart()` is never invoked, so the Promise hangs forever.

**Fix:** After the stream reader signals `done`, if there are no buffered bytes and no active uploads, call `resolve(completedParts)` directly.

**Verified:** Confirmed the deadlock on `@vercel/blob@2.3.2` (hangs for 10+ seconds) and confirmed the fix resolves instantly on the patched version (`2.3.3-f8b7d06-20260402140007`), tested in a real Next.js app.

### Fix 2 — Remove `queueMicrotask` from `createChunkTransformStream`

`createChunkTransformStream` (used in `fetch.ts` when `onUploadProgress` is set) wrapped `transform()` and `flush()` bodies in `queueMicrotask()`. Per the `TransformStream` spec, returning `undefined` from these methods signals "done processing this chunk." The deferred work then runs outside the stream's backpressure mechanism.

This is a **spec-correctness fix**. In practice Node.js microtask ordering makes the current code work, but it's relying on implementation-specific behavior:
- Backpressure is bypassed — the stream feeds data without waiting for the readable side
- `flush()` can race — trailing bytes are enqueued after the readable side thinks flushing is complete

The fix removes the last `queueMicrotask` usage in the blob package and runs the work synchronously, which is correct since it's just array operations on buffer-sized chunks.

**Verified:** Tested `onUploadProgress` with 1MB and 100MB uploads in Node.js, and client uploads (single PUT + multipart) in a browser — progress tracking works correctly on both the patched and released versions, confirming no regression.

## Test plan

- New unit test: `put()` with empty `ReadableStream` + `multipart: true` resolves without hanging
- New unit tests for `createChunkTransformStream`: correct chunking, progress callbacks, flush of trailing bytes
- New e2e test: Playwright test calling a route that does multipart upload with an empty stream, verifying it resolves within 15s
- Manually verified deadlock on 2.3.2 vs patched version in a Next.js app
- Manually verified `onUploadProgress` with 1MB/100MB in Node.js (size match: PASS)
- Manually verified client uploads with progress in browser (single PUT + multipart, 1MB-100MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)