### PR TITLE
fix: handle empty stream error in e2e test route

### DIFF
--- a/test/next/src/app/vercel/blob/api/app/empty-stream-multipart/route.ts
+++ b/test/next/src/app/vercel/blob/api/app/empty-stream-multipart/route.ts
@@ -22,11 +22,20 @@ export async function POST(request: Request): Promise<NextResponse> {
     },
   });
 
-  const blob = await vercelBlob.put(pathname, emptyStream, {
-    access: 'public',
-    multipart: true,
-    addRandomSuffix: true,
-  });
+  try {
+    const blob = await vercelBlob.put(pathname, emptyStream, {
+      access: 'public',
+      multipart: true,
+      addRandomSuffix: true,
+    });
 
-  return NextResponse.json(blob);
+    return NextResponse.json(blob);
+  } catch (error) {
+    // The server rejects empty multipart uploads ("Invalid body") which is
+    // expected. The important thing is that put() resolved instead of hanging.
+    return NextResponse.json(
+      { resolved: true, error: (error as Error).message },
+      { status: 400 },
+    );
+  }
 }

--- a/test/next/test/@vercel/blob/index.test.ts
+++ b/test/next/test/@vercel/blob/index.test.ts
@@ -52,9 +52,10 @@ test.describe('@vercel/blob', () => {
           timeout: 15000, // Should resolve fast, not deadlock
         },
       );
-      // The upload resolves (no deadlock). The server may reject the empty
-      // multipart upload, but the important thing is it doesn't hang.
-      expect(res.status()).toBeLessThan(500);
+      // The server rejects the empty multipart upload (400) which is fine.
+      // The important thing is it resolved instead of hanging (15s timeout).
+      const data = (await res.json()) as { resolved: boolean };
+      expect(data.resolved).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes the failing e2e tests from #1037.

The empty stream multipart e2e test route didn't catch the expected server error ("Invalid body" — the server correctly rejects a 0-part multipart upload). The unhandled error caused a 500, failing the `toBeLessThan(500)` assertion.

**Fix:** Catch the error in the route and return `{ resolved: true }`. The test now checks `resolved === true` — the point is that `put()` resolved (no deadlock), not that the upload succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)