### PR TITLE
fix(blob): include HTTP status in error when client token retrieval fails

### DIFF
--- a/.changeset/fix-blob-client-token-error-message.md
+++ b/.changeset/fix-blob-client-token-error-message.md
@@ -1,0 +1,11 @@
+---
+"@vercel/blob": patch
+---
+
+fix(blob): include HTTP status in error when client token retrieval fails
+
+When `upload()` fails to retrieve a client token from `handleUploadUrl`
+(e.g. the route returns 401, 403, or 500), the error message now includes
+the HTTP status code and status text to help with debugging.
+
+Closes #488

--- a/packages/blob/src/client.browser.test.ts
+++ b/packages/blob/src/client.browser.test.ts
@@ -163,6 +163,25 @@ describe('client', () => {
         },
       );
     });
+
+    it('throws with HTTP status when handleUploadUrl returns an error', async () => {
+      jest.spyOn(undici, 'fetch').mockImplementation(
+        jest.fn().mockResolvedValueOnce({
+          status: 403,
+          statusText: 'Forbidden',
+          ok: false,
+        }),
+      );
+
+      await expect(
+        upload('foo.txt', 'Test file data', {
+          access: 'public',
+          handleUploadUrl: '/api/upload',
+        }),
+      ).rejects.toThrow(
+        'Vercel Blob: Failed to retrieve the client token: 403 Forbidden',
+      );
+    });
   });
 
   describe('multipart upload', () => {

--- a/packages/blob/src/client.ts
+++ b/packages/blob/src/client.ts
@@ -698,7 +698,9 @@ async function retrieveClientToken(options: {
   });
 
   if (!res.ok) {
-    throw new BlobError('Failed to  retrieve the client token');
+    throw new BlobError(
+      `Failed to retrieve the client token: ${res.status} ${res.statusText}`,
+    );
   }
 
   try {


### PR DESCRIPTION
## Summary

Closes #488

When `upload()` fails to retrieve a client token from `handleUploadUrl` (e.g. the route returns 401 or 403 because the user isn't authenticated), the error message previously said:

```
Vercel Blob: Failed to  retrieve the client token
```

(also had a double-space typo)

It now includes the HTTP status code and status text:

```
Vercel Blob: Failed to retrieve the client token: 403 Forbidden
```

This gives developers immediately actionable context without making any assumptions about the format of the response body.

## Changes

- `packages/blob/src/client.ts` — include `res.status` and `res.statusText` in the error message; fix double-space typo
- `packages/blob/src/client.browser.test.ts` — add test asserting the error message format on a non-ok response
- `.changeset/fix-blob-client-token-error-message.md` — patch changeset

## Test plan

- [ ] `pnpm test` in `packages/blob` — all tests pass
- [ ] `upload()` with a `handleUploadUrl` that returns 403 → error message includes `403 Forbidden`