### PR TITLE
ci: enable npm Sigstore provenance on releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,18 @@ env:
   POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
   POSTGRES_URL_NON_POOLING: ${{ secrets.POSTGRES_URL_NON_POOLING }}
   EDGE_CONFIG: ${{ secrets.EDGE_CONFIG }}
+  CI: "true"
+  NPM_CONFIG_PROVENANCE: "true"   # npm reads NPM_CONFIG_* env; pnpm delegates to npm publish
 
 on:
   push:
     branches:
       - main
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write          # required for Sigstore provenance via npm OIDC
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -43,3 +50,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+          NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
# ci: enable npm Sigstore provenance on `@vercel/blob` and sibling releases

**Upstream repo**: https://github.com/vercel/storage
**Proposed branch**: `provenance`
**Type**: routine supply-chain hardening, minimal workflow change
**Prerequisites**: none — applies + works on next release run
**Companion PR**: `vercel/ai` same-pattern change
**Note**: public hardening PR. No embargo, no disclosure coordination, no breach-related language.

## Summary

Enables npm Sigstore SLSA v1 provenance attestation on every package published by this workflow — specifically `@vercel/blob`, `@vercel/kv`, `@vercel/postgres`, `@vercel/edge-config`, `@vercel/analytics`, `@vercel/speed-insights`, `@vercel/flags`.

The diff is byte-identical in intent to the `vercel/ai` companion PR: `permissions: id-token: write` at workflow level, `NPM_CONFIG_PROVENANCE: "true"` at workflow env and at the `changesets/action@v1` step env.

**Why uppercase `NPM_CONFIG_*` not lowercase `pnpm_config_*`**: `pnpm publish` (pnpm 10.11.0) internally invokes `npm publish <tarball> ...`. pnpm itself has no Sigstore/OIDC code path and does not read `pnpm_config_provenance` into its publish flow. Setting `NPM_CONFIG_PROVENANCE=true` puts the config into the subprocess env where npm CLI reads it as a documented config override. Live-tested 2026-04-20; evidence in the research-repo at `evidence/r7-pnpm-10.11.0-live-test.md`.

## Why these packages specifically

Active packages (non-deprecated per README) published by this workflow:

| Package | Weekly installs | Customer-credential handling? |
|---|---:|:---:|
| **`@vercel/blob`** | **3,510,524** | **YES** — reads `BLOB_READ_WRITE_TOKEN` from env, sends as `Bearer` header |
| `@vercel/analytics` | 2,779,632 | no |
| `@vercel/speed-insights` | 1,859,149 | no |
| `@vercel/edge-config` | 649,648 | indirect (edge-config token) |
| `@vercel/flags` | 79,214 | no |

(The deprecated `@vercel/postgres` and `@vercel/kv` packages are listed in the README as migrated to `@neondatabase/serverless` and `@upstash/redis` respectively. While those packages are still publishable from this workflow, new publish cadence is minimal. This PR's provenance change covers them as a side effect, not as the primary motivation.)

`@vercel/blob` is 3.5M weekly installs, actively published, and the runtime behavior reads `BLOB_READ_WRITE_TOKEN` from env and sends it as a `Bearer` header. Attestation coverage gives security-aware customers running `npm audit signatures` or `@sigstore/cli verify` a detection baseline; without it they have nothing to compare new versions against.

Sibling workflows in the same org (`vercel/next.js`, `vercel/turbo`) already ship attestations on publish. This PR brings `vercel/storage` to parity.

## Diff

Identical in intent to the `vercel/ai` PR cover letter's diff. `permissions: id-token: write` at workflow level, `pnpm_config_provenance` env at workflow + step levels, no token changes, no publisher changes.

Patch file: `stage1-storage-provenance.patch`. Applies cleanly against current HEAD of `vercel/storage` main:

```
$ git apply --check stage1-storage-provenance.patch
$ echo $?
0
```

## Prior art (same org)

`vercel/turbo/.github/workflows/turborepo-release.yml` already uses the exact pattern (`NPM_TOKEN` + `id-token: write` + Sigstore provenance via OIDC). That workflow has published production `turbo@*` and `@turbo/*` releases with attestations for months. This PR brings `vercel/storage` to parity.

## Verification after merge

```bash
npm view @vercel/blob@<next-release> --json | jq '.dist.attestations'
# Expected: { "url": "https://registry.npmjs.org/-/npm/v1/attestations/...", "provenance": {...} }
```
