### PR TITLE
Add 'delete' to DelegationOperation for presigned DELETE URLs

### DIFF
--- a/.changeset/presigned-delete.md
+++ b/.changeset/presigned-delete.md
@@ -1,0 +1,5 @@
+---
+"@vercel/blob": patch
+---
+
+Add `delete` to `DelegationOperation` so `issueSignedToken` and `presignUrl` can mint short-lived presigned `DELETE` URLs against `*.blob.vercel-storage.com` object URLs.

--- a/packages/blob/src/signed-token.presignurl.shared-spec.ts
+++ b/packages/blob/src/signed-token.presignurl.shared-spec.ts
@@ -191,6 +191,61 @@ export function registerPresignUrlTests(suiteName = 'presignUrl'): void {
       expect(u.searchParams.get(BLOB_PRESIGN_QUERY_SIGNATURE)).toBe(expected);
     });
 
+    it('DELETE: HMACs canonical against the blob object URL', async () => {
+      const pathname = 'images/a.png';
+      const delegation = createDelegationToken(
+        {
+          storeId: `store_${storeId}`,
+          ownerId: 'owner_1',
+          pathname,
+          operations: ['delete'],
+          validUntil: now + 3600_000,
+          iat: now,
+        },
+        blobSigningSecret,
+      );
+      const client = deriveClientSigningToken(blobSigningSecret, delegation);
+      const base = `https://store_${storeId}.public.blob.vercel-storage.com/${pathname}`;
+      const presigned = await presignUrl(
+        base,
+        { delegationToken: delegation, clientSigningToken: client },
+        'delete',
+      );
+      const u = new URL(presigned);
+      const canonical = `operation=delete\npathname=${pathname}`;
+      const expected = createHmac('sha256', client)
+        .update(canonical, 'utf8')
+        .digest('base64url');
+      expect(u.searchParams.get(BLOB_PRESIGN_QUERY_SIGNATURE)).toBe(expected);
+      expect(u.searchParams.get(BLOB_PRESIGN_QUERY_DELEGATION)).toBe(
+        delegation,
+      );
+    });
+
+    it('rejects DELETE when the delegation does not include `delete`', async () => {
+      const pathname = 'a.png';
+      const delegation = createDelegationToken(
+        {
+          storeId: `store_${storeId}`,
+          ownerId: 'o',
+          pathname,
+          operations: ['get', 'head'],
+          validUntil: now + 3600_000,
+          iat: now,
+        },
+        blobSigningSecret,
+      );
+      const client = deriveClientSigningToken(blobSigningSecret, delegation);
+      const base = `https://store_${storeId}.public.blob.vercel-storage.com/${pathname}`;
+      await expect(
+        presignUrl(
+          base,
+          { delegationToken: delegation, clientSigningToken: client },
+          'delete',
+        ),
+      ).rejects.toThrow(BlobError);
+    });
+
     it('rejects PUT when the URL is a `*.blob.vercel-storage.com` object URL', async () => {
       const pathname = 'a.png';
       const delegation = createDelegationToken(

--- a/packages/blob/src/signed-token.ts
+++ b/packages/blob/src/signed-token.ts
@@ -5,9 +5,10 @@ import { type BlobCommandOptions, BlobError, getApiUrl } from './helpers';
 /**
  * Operations that may be encoded in a delegation token (e.g. read: `get` / `head`,
  * write: `upload` for presigned control-plane writes — both single-object `PUT`
- * ({@link controlPlaneBlobPutUrl}) and multipart `POST` ({@link controlPlaneBlobMpuUrl})).
+ * ({@link controlPlaneBlobPutUrl}) and multipart `POST` ({@link controlPlaneBlobMpuUrl}),
+ * destructive: `delete` for presigned `DELETE` against the blob object URL).
  */
-export type DelegationOperation = 'get' | 'head' | 'upload';
+export type DelegationOperation = 'get' | 'head' | 'upload' | 'delete';
 
 /** Excluded from the string-to-sign; added after signing. @public for CDN / tooling alignment */
 export const BLOB_PRESIGN_QUERY_DELEGATION = 'vercel-blob-delegation' as const;
@@ -58,7 +59,8 @@ export type IssueSignedTokenOptions = BlobCommandOptions &
     pathname?: string;
     /**
      * Allowed operations (e.g. `get` / `head` for reads to `*.blob.vercel-storage.com`,
-     * `upload` for presigned control-plane `PUT` and multipart `POST /mpu`).
+     * `upload` for presigned control-plane `PUT` and multipart `POST /mpu`,
+     * `delete` for presigned `DELETE` against `*.blob.vercel-storage.com`).
      * When omitted, the API defaults to read (`get`) only.
      */
     operations?: DelegationOperation[];
@@ -432,7 +434,8 @@ export type PresignUrlOptions = {
 
 /**
  * Builds a **presigned URL** (read: `GET` / `HEAD` to `publicBlobObjectUrl`, or write:
- * `PUT` to {@link controlPlaneBlobPutUrl}, or multipart `POST` to {@link controlPlaneBlobMpuUrl})
+ * `PUT` to {@link controlPlaneBlobPutUrl}, or multipart `POST` to {@link controlPlaneBlobMpuUrl},
+ * or destructive: `DELETE` to `publicBlobObjectUrl`)
  * by HMACing a canonical string with `clientSigningToken` and appending the delegation
  * and signature as query parameters. The CDN re-derives the signing key from
  * `delegationToken` and validates the HMAC, scope, and expiry.
@@ -442,10 +445,11 @@ export type PresignUrlOptions = {
  *
  * Sorted newline-separated `key=value` pairs (UTF-8 byte order of whole lines):
  *
- * - `operation=get`, `operation=head`, or `operation=upload` (implicit from URL
- *   target: object host + GET/HEAD vs control-plane PUT/POST for uploads).
- * - `pathname=<object key>`: from the URL path (reads) or the `pathname` query
- *   (control-plane `PUT` / `POST` uploads).
+ * - `operation=get`, `operation=head`, `operation=upload`, or `operation=delete`
+ *   (implicit from URL target: object host + GET/HEAD/DELETE vs control-plane
+ *   PUT/POST for uploads).
+ * - `pathname=<object key>`: from the URL path (reads / deletes) or the
+ *   `pathname` query (control-plane `PUT` / `POST` uploads).
  * - `vercel-blob-url-expires=<ms>` when `options.ttlSeconds` is set.
  *
  * Only these keys participate. Other query params are ignored. Delegation and
@@ -532,6 +536,11 @@ export async function presignUrl(
   if (operation === 'upload' && !scope.operations?.includes('upload')) {
     throw new BlobError(
       'The delegation token is not valid for presigned write requests. Include `"upload"` in `operations` when calling `issueSignedToken`.',
+    );
+  }
+  if (operation === 'delete' && !scope.operations?.includes('delete')) {
+    throw new BlobError(
+      'The delegation token is not valid for `DELETE` requests. Include `"delete"` in `operations` when calling `issueSignedToken`.',
     );
   }
 


### PR DESCRIPTION
# Problem

#1057 lets clients mint presigned URLs for `get` / `head` / `upload`, but not for `delete`. Customers asking for short-lived destructive links currently can't use the SDK without a full read-write token.

The API side (vercel/api#71430) just added `'delete'` to the allowed delegation operations on `issue_signed_token`. This PR mirrors that on the SDK so a token issued with `operations: ['delete']` can actually be turned into a presigned URL.

# Solution

- Add `'delete'` to `DelegationOperation`. `'delete'` follows the same URL-shape contract as `get` / `head`: the user signs a `*.blob.vercel-storage.com` object URL and issues an HTTP `DELETE` against it (the canonical signed string is `operation=delete\npathname=<key>`).
- `presignUrl` gains a scope-includes-`'delete'` gate parallel to the existing `get` / `head` / `upload` checks.
- Added two shared-spec tests (run in node + jsdom): canonical signing for `'delete'`, and rejection when the delegation does not include `'delete'`.

> Based on `elliot/presigned-urls`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)