### PR TITLE
feat(blob): presigned HEAD URLs

### DIFF
--- a/packages/blob/src/index.ts
+++ b/packages/blob/src/index.ts
@@ -242,6 +242,7 @@ export type {
   IssueSignedTokenOptions,
   PresignDeleteUrlOptions,
   PresignGetUrlOptions,
+  PresignHeadUrlOptions,
   PresignPutUrlOptions,
   PresignUrlOptions,
   PresignUrlResult,

--- a/packages/blob/src/presign-query-params.ts
+++ b/packages/blob/src/presign-query-params.ts
@@ -271,7 +271,7 @@ export function resolvePresignUrlValidUntilMs(args: {
  * defaults to delegation expiry).
  */
 export function buildPresignCanonicalQueryEntries(args: {
-  operation: 'get' | 'put' | 'delete';
+  operation: 'get' | 'head' | 'put' | 'delete';
   delegation: DelegationScopeForPresign;
   urlOptions?: {
     validUntil?: number;

--- a/packages/blob/src/signed-token.ts
+++ b/packages/blob/src/signed-token.ts
@@ -15,11 +15,14 @@ import {
 } from './presign-query-params';
 
 /**
- * Operations that may be encoded in a delegation token (e.g. read: `get`,
- * write: `put` for presigned control-plane writes — both single-object `PUT`,
- * destructive: `delete` for presigned control-plane `DELETE /?pathname=…`).
+ * Operations that may be encoded in a delegation token (e.g. read: `get` /
+ * `head` for blob object reads, write: `put` for presigned control-plane writes
+ * — both single-object `PUT`, destructive: `delete` for presigned control-plane
+ * `DELETE /?pathname=…`). `head` shares the GET URL shape (blob object host)
+ * and is distinguished only by the HTTP method and `operation=head` in the
+ * canonical signing string.
  */
-export type DelegationOperation = 'get' | 'put' | 'delete';
+export type DelegationOperation = 'get' | 'head' | 'put' | 'delete';
 
 /** Excluded from the string-to-sign; added after signing. @public for CDN / tooling alignment */
 export const BLOB_PRESIGN_QUERY_DELEGATION = 'vercel-blob-delegation' as const;
@@ -312,6 +315,20 @@ export type PresignGetUrlOptions = {
 };
 
 /**
+ * Presign URL options for {@link presignUrl} when `operation` is `head`.
+ * Mirrors {@link PresignGetUrlOptions}; the CDN URL is identical, the HTTP
+ * method differentiates, and the canonical signing string carries
+ * `operation=head` so a GET-signed URL cannot be replayed for HEAD.
+ */
+export type PresignHeadUrlOptions = {
+  operation: 'head';
+
+  pathname: string;
+
+  validUntil?: number;
+};
+
+/**
  * Presign URL options for {@link presignUrl} when `operation` is `put` (single `PUT` or multipart `POST`).
  * Serialized as individual `vercel-blob-*` query params (see {@link PRESIGN_CANONICAL_QUERY_KEYS}).
  */
@@ -359,6 +376,7 @@ export type PresignDeleteUrlOptions = {
 
 export type PresignUrlOptions =
   | PresignGetUrlOptions
+  | PresignHeadUrlOptions
   | PresignPutUrlOptions
   | PresignDeleteUrlOptions;
 
@@ -400,6 +418,11 @@ export async function presign(
   if (options.operation === 'get' && !scope.operations?.includes('get')) {
     throw new BlobError(
       'The delegation token is not valid for `GET` requests. Include `"get"` in `operations` when calling `issueSignedToken`.',
+    );
+  }
+  if (options.operation === 'head' && !scope.operations?.includes('head')) {
+    throw new BlobError(
+      'The delegation token is not valid for `HEAD` requests. Include `"head"` in `operations` when calling `issueSignedToken`.',
     );
   }
   if (options.operation === 'put' && !scope.operations?.includes('put')) {
@@ -492,6 +515,8 @@ export type PresignUrlResult = {
  * Builds a presigned URL for `GET` / `HEAD` (blob object host), `PUT` / multipart (control API),
  * or `DELETE` (`DELETE /?pathname=…` on the control API — mirrors the PUT URL shape; the
  * HTTP method discriminates, and the canonical signing string includes `operation=delete`).
+ * `HEAD` reuses the GET URL shape against the blob object host; `operation=head` in the
+ * canonical string prevents a GET-signed URL from being replayed as a HEAD.
  */
 export async function presignUrl(
   signedToken: Pick<
@@ -502,7 +527,7 @@ export async function presignUrl(
 ): Promise<PresignUrlResult> {
   const payload = await presign(signedToken, options);
 
-  if (options.operation === 'get') {
+  if (options.operation === 'get' || options.operation === 'head') {
     return {
       presignedUrl: buildPresignedGetUrl(options.pathname, payload, options),
     };

--- a/test/next/src/app/vercel/blob/api/app/presigned-head/route.ts
+++ b/test/next/src/app/vercel/blob/api/app/presigned-head/route.ts
@@ -1,0 +1,67 @@
+import { issueSignedToken, presignUrl } from '@vercel/blob';
+import { NextResponse } from 'next/server';
+
+function parseBlobObjectUrl(
+  blobUrl: string,
+): { access: 'public' | 'private'; pathname: string } | null {
+  let u: URL;
+  try {
+    u = new URL(blobUrl);
+  } catch {
+    return null;
+  }
+  const { hostname } = u;
+  if (hostname.endsWith('.public.blob.vercel-storage.com')) {
+    return { access: 'public', pathname: pathnameFromObjectUrl(u.pathname) };
+  }
+  if (hostname.endsWith('.private.blob.vercel-storage.com')) {
+    return { access: 'private', pathname: pathnameFromObjectUrl(u.pathname) };
+  }
+  return null;
+}
+
+function pathnameFromObjectUrl(urlPathname: string): string {
+  const trimmed = urlPathname.startsWith('/')
+    ? urlPathname.slice(1)
+    : urlPathname;
+  return trimmed
+    .split('/')
+    .map((segment) => decodeURIComponent(segment))
+    .join('/');
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const body = (await request.json()) as { url?: string };
+  if (!body.url || typeof body.url !== 'string') {
+    return NextResponse.json({ error: 'url is required' }, { status: 400 });
+  }
+
+  const parsed = parseBlobObjectUrl(body.url);
+  if (!parsed) {
+    return NextResponse.json(
+      {
+        error:
+          'url must be a Vercel Blob object URL (*.public|*.private.blob.vercel-storage.com)',
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const token = await issueSignedToken({
+      pathname: parsed.pathname,
+      operations: ['head'],
+      validUntil: Date.now() + 60 * 60 * 1000, // 1 hour
+    });
+    const { presignedUrl } = await presignUrl(token, {
+      operation: 'head',
+      pathname: parsed.pathname,
+      access: parsed.access,
+      validUntil: Date.now() + 30 * 60 * 1000, // 30 minutes
+    });
+    return NextResponse.json({ presignedUrl });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/test/next/src/app/vercel/blob/app/presigned-upload/client/page.tsx
+++ b/test/next/src/app/vercel/blob/app/presigned-upload/client/page.tsx
@@ -15,8 +15,45 @@ export default function AppPresignedUpload(): React.JSX.Element {
   );
   const [deleteStatus, setDeleteStatus] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [headStatus, setHeadStatus] = useState<string | null>(null);
+  const [headError, setHeadError] = useState<string | null>(null);
   const [progressEvents, setProgressEvents] = useState<string[]>([]);
   const searchParams = useSearchParams();
+
+  const handlePresignedHead = async (blobUrl: string): Promise<void> => {
+    setHeadStatus(null);
+    setHeadError(null);
+    try {
+      const issueRes = await fetch(`${API_ROOT}/presigned-head`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: blobUrl }),
+      });
+      const issueJson = (await issueRes.json()) as {
+        presignedUrl?: string;
+        error?: string;
+      };
+      if (!issueRes.ok || !issueJson.presignedUrl) {
+        setHeadError(
+          issueJson.error ?? issueRes.statusText ?? 'presigned-head failed',
+        );
+        return;
+      }
+      const headRes = await fetch(issueJson.presignedUrl, { method: 'HEAD' });
+      if (!headRes.ok) {
+        setHeadError(`HTTP ${headRes.status}: ${headRes.statusText}`);
+        return;
+      }
+      const summary = [
+        `status=${headRes.status}`,
+        `content-type=${headRes.headers.get('content-type') ?? '-'}`,
+        `content-length=${headRes.headers.get('content-length') ?? '-'}`,
+      ].join(' • ');
+      setHeadStatus(summary);
+    } catch (err) {
+      setHeadError(err instanceof Error ? err.message : String(err));
+    }
+  };
 
   const handlePresignedDelete = async (blobUrl: string): Promise<void> => {
     setDeleteStatus(null);
@@ -192,6 +229,16 @@ export default function AppPresignedUpload(): React.JSX.Element {
             </video>
           ) : null}
           <button
+            className="mt-2 mr-2 bg-blue-300 hover:bg-blue-400 text-gray-800 font-bold py-2 px-4 rounded-sm inline-flex items-center"
+            data-testid="presigned-head-button"
+            onClick={() => {
+              void handlePresignedHead(blob.url);
+            }}
+            type="button"
+          >
+            HEAD (presigned)
+          </button>
+          <button
             className="mt-2 bg-red-300 hover:bg-red-400 text-gray-800 font-bold py-2 px-4 rounded-sm inline-flex items-center"
             data-testid="presigned-delete-button"
             onClick={() => {
@@ -202,6 +249,23 @@ export default function AppPresignedUpload(): React.JSX.Element {
             Delete (presigned)
           </button>
         </div>
+      ) : null}
+
+      {headStatus ? (
+        <p
+          className="mt-2 text-sm text-green-700"
+          data-testid="presigned-head-status"
+        >
+          {headStatus}
+        </p>
+      ) : null}
+      {headError ? (
+        <p
+          className="mt-2 text-sm text-red-700"
+          data-testid="presigned-head-error"
+        >
+          Presigned HEAD failed: {headError}
+        </p>
       ) : null}
 
       {deleteStatus ? (


### PR DESCRIPTION
## Summary

`HEAD` mirrors `GET` against the blob object host (`<storeId>.<access>.blob.vercel-storage.com/<pathname>`) — the URL shape is identical, the HTTP method discriminates, and `operation=head` goes into the canonical signing string so a GET-signed URL cannot be replayed as a HEAD (and vice versa).

- `'head'` added to `DelegationOperation`.
- `PresignHeadUrlOptions` — same shape as `PresignGetUrlOptions` (`pathname`, optional `validUntil`).
- `presign()` gates on the delegation scope including `'head'`.
- `presignUrl()` reuses `buildPresignedGetUrl()` for `operation: 'head'`.
- `buildPresignCanonicalQueryEntries()` for `head` emits only `validUntil` (when below the delegation ceiling) — same as `get`.
- E2E test route + HEAD button on the presigned-upload demo page.

```ts
const token = await issueSignedToken({
  pathname: 'media/photo.png',
  operations: ['head'],
  validUntil: Date.now() + 60 * 60 * 1000,
});

const { presignedUrl } = await presignUrl(token, {
  operation: 'head',
  pathname: 'media/photo.png',
  access: 'public',
});

const res = await fetch(presignedUrl, { method: 'HEAD' });
// res.headers.get('content-type'), res.headers.get('content-length'), ...
```

> Stacked on `falcoagustin/presigned-delete-impl` (#1064). Will need to be retargeted to `elliot/presigned-urls` (#1057) once #1064 lands.

## Test plan

- [x] `pnpm type-check` and `pnpm test:node` / `pnpm test:browser` pass in `packages/blob`
- [ ] Manual smoke test against staging via the `/vercel/blob/app/presigned-upload/client` page (upload → HEAD button → 200 with content-type/length surfaced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)