### PR TITLE
ci: declare workflow-level `contents: read` on 5 workflows

### DIFF
--- a/.github/workflows/deprecate-package.yml
+++ b/.github/workflows/deprecate-package.yml
@@ -23,6 +23,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   deprecate:
     name: Deprecate Package

--- a/.github/workflows/integration-tests-dev.yml
+++ b/.github/workflows/integration-tests-dev.yml
@@ -20,6 +20,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   biome:
     name: "Biome"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,6 +13,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: 'Test'

--- a/.github/workflows/visual-tests-schedule.yml
+++ b/.github/workflows/visual-tests-schedule.yml
@@ -22,6 +22,9 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 5 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `integration-tests-live.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.