### PR TITLE
Update pnpm-workspace.yaml to enforce minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ packages:
   - 'packages/*'
   - 'tooling/*'
   - 'test/*'
+
+minimumReleaseAge: 2880


### PR DESCRIPTION
Updates pnpm-workspace.yaml to enforce a minimum release age for dependencies