### PR TITLE
ci: enable npm provenance attestation on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,12 @@
 # Trusted publishing requires Node >= 22.14.0 and npm >= 11.5.1, which is why
 # we pin `node-version: latest` here. The `id-token: write` permission below
 # is what allows GitHub Actions to mint the OIDC token npm uses to verify us.
+#
+# Provenance: each publishable package sets `publishConfig.provenance: true` in
+# its package.json, so `npm publish` (invoked by `changeset publish`) generates
+# npm provenance attestations. This relies on the `id-token: write` permission
+# and a GitHub-hosted runner. See:
+#   https://docs.npmjs.com/generating-provenance-statements
 
 name: Release
 

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -8,6 +8,9 @@
     "url": "https://github.com/vercel/storage.git",
     "directory": "packages/blob"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "license": "Apache-2.0",
   "sideEffects": false,
   "type": "module",

--- a/packages/edge-config-fs/package.json
+++ b/packages/edge-config-fs/package.json
@@ -8,6 +8,9 @@
     "url": "https://github.com/vercel/storage.git",
     "directory": "packages/edge-config-fs"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "license": "Apache-2.0",
   "sideEffects": false,
   "type": "module",

--- a/packages/edge-config/package.json
+++ b/packages/edge-config/package.json
@@ -8,6 +8,9 @@
     "url": "https://github.com/vercel/storage.git",
     "directory": "packages/edge-config"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "license": "Apache-2.0",
   "sideEffects": false,
   "type": "module",


### PR DESCRIPTION
## What

Enables [npm provenance attestation](https://docs.npmjs.com/generating-provenance-statements) for our published packages.

The repo already publishes via Trusted Publishing (OIDC) in `release.yml`, with `id-token: write` and a GitHub-hosted runner — the prerequisites for provenance. The missing piece was telling npm to generate provenance, since `changeset publish` wraps `npm publish` (a third-party publishing tool).

Per the npm docs' guidance for third-party publishing tools, this adds `publishConfig.provenance: true` to each publishable package:

- `@vercel/blob`
- `@vercel/edge-config`
- `@vercel/edge-config-fs`

```json
"publishConfig": {
  "provenance": true
}
```

A comment block in `release.yml` documents how provenance is wired up.

## Notes

- All three packages already have a public, case-matching `repository` field with `directory` set — required for provenance.
- No workflow changes needed beyond the doc comment; `id-token: write` and the GitHub-hosted runner are already in place.
- The snapshot release path also generates provenance (same workflow, same OIDC setup). This is harmless and arguably more correct.
- Verify after a release with `npm audit signatures`.