### PR TITLE
[@vercel/blob] Add rename operation

### DIFF
--- a/.changeset/blob-rename.md
+++ b/.changeset/blob-rename.md
@@ -1,0 +1,5 @@
+---
+'@vercel/blob': minor
+---
+
+Add `rename(fromUrlOrPathname, toPathname, options)` to move a blob to another pathname. The blob is copied to the new pathname and the source is deleted afterwards; if the copy fails the source is left untouched. By default renaming onto an existing blob throws — pass `allowOverwrite: true` to replace it, or `addRandomSuffix: true` to generate a unique destination. Requires a read-write token (client tokens are not supported).

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -14,6 +14,7 @@ import {
   head,
   list,
   put,
+  rename,
   uploadPart,
 } from './index';
 
@@ -1311,6 +1312,136 @@ describe('blob client', () => {
         access: 'public',
       });
       expect(headers['x-vercel-blob-access']).toEqual('public');
+    });
+  });
+
+  describe('rename', () => {
+    const mockedRenameResult = {
+      url: `${BLOB_STORE_BASE_URL}/destination.txt`,
+      downloadUrl: `${BLOB_STORE_BASE_URL}/destination.txt?download=1`,
+      pathname: 'destination.txt',
+      contentType: 'text/plain',
+      contentDisposition: 'attachment; filename="destination.txt"',
+      etag: '"def456"',
+    };
+
+    it('throws when filepath is too long', async () => {
+      await expect(
+        rename('source', 'a'.repeat(951), {
+          access: 'public',
+        }),
+      ).rejects.toThrow(
+        new Error('Vercel Blob: pathname is too long, maximum length is 950'),
+      );
+    });
+
+    it('should throw when using an invalid access value', async () => {
+      await expect(
+        rename('source', 'destination.txt', {
+          // @ts-expect-error: testing that an invalid value throws
+          access: 'invalid',
+        }),
+      ).rejects.toThrow(
+        new Error(
+          'Vercel Blob: access must be "private" or "public", see https://vercel.com/docs/vercel-blob',
+        ),
+      );
+    });
+
+    it('should rename a file with a POST to /rename', async () => {
+      let path: string | null = null;
+      let headers: Record<string, string> = {};
+
+      mockClient
+        .intercept({
+          path: () => true,
+          method: 'POST',
+        })
+        .reply(200, (req) => {
+          path = req.path;
+          headers = req.headers as Record<string, string>;
+          return mockedRenameResult;
+        });
+
+      await expect(
+        rename('source.txt', 'destination.txt', {
+          access: 'public',
+        }),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "contentDisposition": "attachment; filename="destination.txt"",
+          "contentType": "text/plain",
+          "downloadUrl": "https://storeId.public.blob.vercel-storage.com/destination.txt?download=1",
+          "etag": ""def456"",
+          "pathname": "destination.txt",
+          "url": "https://storeId.public.blob.vercel-storage.com/destination.txt",
+        }
+      `);
+      expect(path).toEqual(
+        '/api/blob/rename?pathname=destination.txt&fromUrl=source.txt',
+      );
+      expect(headers['x-vercel-blob-access']).toEqual('public');
+    });
+
+    it('sets the x-vercel-blob-access header for private access on rename', async () => {
+      let headers: Record<string, string> = {};
+
+      mockClient
+        .intercept({
+          path: () => true,
+          method: 'POST',
+        })
+        .reply(200, (req) => {
+          headers = req.headers as Record<string, string>;
+          return mockedRenameResult;
+        });
+
+      await rename('source.txt', 'destination.txt', {
+        access: 'private',
+      });
+      expect(headers['x-vercel-blob-access']).toEqual('private');
+    });
+
+    it('sets the allowOverwrite and addRandomSuffix headers', async () => {
+      let headers: Record<string, string> = {};
+
+      mockClient
+        .intercept({
+          path: () => true,
+          method: 'POST',
+        })
+        .reply(200, (req) => {
+          headers = req.headers as Record<string, string>;
+          return mockedRenameResult;
+        });
+
+      await rename('source.txt', 'destination.txt', {
+        access: 'public',
+        allowOverwrite: true,
+        addRandomSuffix: true,
+      });
+      expect(headers['x-allow-overwrite']).toEqual('1');
+      expect(headers['x-add-random-suffix']).toEqual('1');
+    });
+
+    it('should send x-if-match header when ifMatch option is provided', async () => {
+      let headers: Record<string, string> = {};
+
+      mockClient
+        .intercept({
+          path: () => true,
+          method: 'POST',
+        })
+        .reply(200, (req) => {
+          headers = req.headers as Record<string, string>;
+          return mockedRenameResult;
+        });
+
+      await rename('source.txt', 'destination.txt', {
+        access: 'public',
+        ifMatch: '"source-etag"',
+      });
+      expect(headers['x-if-match']).toEqual('"source-etag"');
     });
   });
 

--- a/packages/blob/src/index.ts
+++ b/packages/blob/src/index.ts
@@ -103,6 +103,11 @@ export { list } from './list';
 export type { CopyBlobResult, CopyCommandOptions } from './copy';
 export { copy } from './copy';
 
+// vercelBlob.rename()
+
+export type { RenameBlobResult, RenameCommandOptions } from './rename';
+export { rename } from './rename';
+
 // vercelBlob. createMultipartUpload()
 // vercelBlob. uploadPart()
 // vercelBlob. completeMultipartUpload()

--- a/packages/blob/src/rename.ts
+++ b/packages/blob/src/rename.ts
@@ -21,7 +21,7 @@ export interface RenameBlobResult {
  * copied to the new pathname and the source blob is deleted afterwards. If
  * the copy fails, the source blob is left untouched.
  *
- * @param fromUrlOrPathname - The blob URL (or pathname) to rename. You can only rename blobs that are in the store, that your 'BLOB_READ_WRITE_TOKEN' has access to.
+ * @param fromUrlOrPathname - The blob URL (or pathname) to rename. You can only rename blobs that are in the store your token has access to.
  * @param toPathname - The pathname to rename the blob to. This includes the filename.
  * @param options - Additional options. The rename method will not preserve any metadata configuration (e.g.: 'cacheControlMaxAge') of the source blob. If you want to keep the metadata, you need to define it here again.
  */

--- a/packages/blob/src/rename.ts
+++ b/packages/blob/src/rename.ts
@@ -1,0 +1,105 @@
+import { MAXIMUM_PATHNAME_LENGTH, requestApi } from './api';
+import type { CommonCreateBlobOptions } from './helpers';
+import { BlobError, disallowedPathnameCharacters } from './helpers';
+
+export type RenameCommandOptions = CommonCreateBlobOptions;
+
+export interface RenameBlobResult {
+  url: string;
+  downloadUrl: string;
+  pathname: string;
+  contentType: string;
+  contentDisposition: string;
+  /**
+   * The ETag of the blob. Can be used with `ifMatch` for conditional writes.
+   */
+  etag: string;
+}
+
+/**
+ * Renames (moves) a blob to another pathname in your store. The blob is
+ * copied to the new pathname and the source blob is deleted afterwards. If
+ * the copy fails, the source blob is left untouched.
+ *
+ * @param fromUrlOrPathname - The blob URL (or pathname) to rename. You can only rename blobs that are in the store, that your 'BLOB_READ_WRITE_TOKEN' has access to.
+ * @param toPathname - The pathname to rename the blob to. This includes the filename.
+ * @param options - Additional options. The rename method will not preserve any metadata configuration (e.g.: 'cacheControlMaxAge') of the source blob. If you want to keep the metadata, you need to define it here again.
+ */
+export async function rename(
+  fromUrlOrPathname: string,
+  toPathname: string,
+  options: RenameCommandOptions,
+): Promise<RenameBlobResult> {
+  if (!options) {
+    throw new BlobError('missing options, see usage');
+  }
+
+  if (options.access !== 'public' && options.access !== 'private') {
+    throw new BlobError(
+      'access must be "private" or "public", see https://vercel.com/docs/vercel-blob',
+    );
+  }
+
+  if (toPathname.length > MAXIMUM_PATHNAME_LENGTH) {
+    throw new BlobError(
+      `pathname is too long, maximum length is ${MAXIMUM_PATHNAME_LENGTH}`,
+    );
+  }
+
+  for (const invalidCharacter of disallowedPathnameCharacters) {
+    if (toPathname.includes(invalidCharacter)) {
+      throw new BlobError(
+        `pathname cannot contain "${invalidCharacter}", please encode it if needed`,
+      );
+    }
+  }
+
+  const headers: Record<string, string> = {};
+
+  // access is always required, so always add it to headers
+  headers['x-vercel-blob-access'] = options.access;
+
+  if (options.addRandomSuffix !== undefined) {
+    headers['x-add-random-suffix'] = options.addRandomSuffix ? '1' : '0';
+  }
+
+  if (options.allowOverwrite !== undefined) {
+    headers['x-allow-overwrite'] = options.allowOverwrite ? '1' : '0';
+  }
+
+  if (options.contentType) {
+    headers['x-content-type'] = options.contentType;
+  }
+
+  if (options.cacheControlMaxAge !== undefined) {
+    headers['x-cache-control-max-age'] = options.cacheControlMaxAge.toString();
+  }
+
+  if (options.ifMatch) {
+    headers['x-if-match'] = options.ifMatch;
+  }
+
+  const params = new URLSearchParams({
+    pathname: toPathname,
+    fromUrl: fromUrlOrPathname,
+  });
+
+  const response = await requestApi<RenameBlobResult>(
+    `/rename?${params.toString()}`,
+    {
+      method: 'POST',
+      headers,
+      signal: options.abortSignal,
+    },
+    options,
+  );
+
+  return {
+    url: response.url,
+    downloadUrl: response.downloadUrl,
+    pathname: response.pathname,
+    contentType: response.contentType,
+    contentDisposition: response.contentDisposition,
+    etag: response.etag,
+  };
+}

--- a/packages/blob/src/rename.ts
+++ b/packages/blob/src/rename.ts
@@ -22,7 +22,7 @@ export interface RenameBlobResult {
  * the copy fails, the source blob is left untouched.
  *
  * @param fromUrlOrPathname - The blob URL (or pathname) to rename. You can only rename blobs that are in the store your token has access to.
- * @param toPathname - The pathname to rename the blob to. This includes the filename.
+ * @param toPathname - The pathname to rename the blob to.
  * @param options - Additional options. The rename method will not preserve any metadata configuration (e.g.: 'cacheControlMaxAge') of the source blob. If you want to keep the metadata, you need to define it here again.
  */
 export async function rename(


### PR DESCRIPTION
## What

Add `rename(fromUrlOrPathname, toPathname, options)` to move a blob to another pathname. The blob is copied to the new pathname and the source is deleted afterwards; if the copy fails the source is left untouched. By default renaming onto an existing blob throws — pass `allowOverwrite: true` to replace it, or `addRandomSuffix: true` to generate a unique destination. Requires a read-write token (client tokens are not supported).

## Why

- The Blob API recently gained a `POST /rename` endpoint (server-side copy + delete of the source), but the SDK has no way to call it — dashboards/apps had to fall back to `copy` + `del` with no atomicity guarantees around the destination-exists check.
- Adds `rename(fromUrlOrPathname, toPathname, options)` mirroring `copy()`'s options: `access` (required), `allowOverwrite`, `addRandomSuffix`, `contentType`, `cacheControlMaxAge`, `ifMatch`. Renaming onto an existing blob throws by default (the API fails closed); `allowOverwrite: true` opts into replacing it.
- Server-only export (`index.ts`, not `client.ts`): the endpoint rejects client tokens.

## Validation

- Unit tests assert the wire format the API expects: `POST /rename?pathname=…&fromUrl=…` with `x-vercel-blob-access` (required by the endpoint), and pass-through of `x-allow-overwrite`, `x-add-random-suffix`, and `x-if-match` headers.
- Rename requires `x-api-version` ≥ 9; the SDK sends 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)