### PR TITLE
fix: refactor createChunkTransformStream type definitions

### DIFF
--- a/packages/blob/src/helpers.ts
+++ b/packages/blob/src/helpers.ts
@@ -455,15 +455,16 @@ export function computeBodyLength(body: PutBody): number {
 export const createChunkTransformStream = (
   chunkSize: number,
   onProgress?: (bytes: number) => void,
-): TransformStream<ArrayBuffer | Uint8Array> => {
+): TransformStream<ArrayBuffer | Uint8Array, Uint8Array> => {
   let buffer = new Uint8Array(0);
 
-  return new TransformStream<ArrayBuffer, Uint8Array>({
+  return new TransformStream<ArrayBuffer | Uint8Array, Uint8Array>({
     transform(chunk, controller) {
       // Combine the new chunk with any leftover data
-      const newBuffer = new Uint8Array(buffer.length + chunk.byteLength);
+      const chunkData = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+      const newBuffer = new Uint8Array(buffer.length + chunkData.byteLength);
       newBuffer.set(buffer);
-      newBuffer.set(new Uint8Array(chunk), buffer.length);
+      newBuffer.set(chunkData, buffer.length);
       buffer = newBuffer;
 
       // Output complete chunks


### PR DESCRIPTION
fix  `blob/src/helpers.ts`, rewrite `createChunkTransformStream` so it creates an identity `TransformStream<ArrayBuffer | Uint8Array, Uint8Array>()` and returns `new ReadableStream<ArrayBuffer | Uint8Array>({...}).pipeThrough(transform)`, where the chunking logic is implemented in the `ReadableStream` source and then piped through the transform.  
However, that would be a larger refactor. A smaller and behavior-preserving fix is to align the constructor generics with the declared return and chunk usage: construct `new TransformStream<ArrayBuffer | Uint8Array, Uint8Array>({...})` and normalize `chunk` handling with `chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk)`. This removes signature ambiguity and keeps the same output/progress behavior.


**Refferences**
Function calls in JavaScript may pass an arbitrary number of arguments to the invoked function. If the invoked function declares fewer parameters than arguments were passed, the remaining arguments can only be accessed through the arguments object. Hence, if a function is passed too many arguments but does not use the arguments object, the remaining arguments are useless. Such calls often indicate incomplete refactorings, or may point to a misunderstanding of the functionality of the invoked function.

- Ecma International, ECMAScript Language Definition, 5.1 Edition, Section 10. ECMA, 2011.
- CWE-685