### PR TITLE
fix(edge-config): stale-if-error expiry check was inverted

### DIFF
--- a/.changeset/stale-if-error-expiry-fix.md
+++ b/.changeset/stale-if-error-expiry-fix.md
@@ -1,0 +1,8 @@
+---
+'@vercel/edge-config': patch
+'@vercel/global-config': patch
+---
+
+fix: correct the `stale-if-error` expiry computation so stale content is no longer served indefinitely once the configured window has passed.
+
+The previous condition compared the cache's timestamp to `Date.now() + staleIfError * 1000`, which was always true for any positive `staleIfError`, so `stale-if-error` caches never expired. It now checks `Date.now() < cacheTime + staleIfError * 1000`, only serving stale content within the configured window. The same correction is applied to the network-error path (`createHandleStaleIfErrorException`).

--- a/packages/edge-config/src/utils/fetch-with-cached-response.test.ts
+++ b/packages/edge-config/src/utils/fetch-with-cached-response.test.ts
@@ -178,6 +178,28 @@ describe('fetchWithCachedResponse', () => {
     await expect(data2.json()).resolves.toEqual({ name: 'John' });
   });
 
+  it('should NOT serve stale content after stale-if-error window expires', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ name: 'John' }), {
+      headers: { ETag: 'abc123', 'content-type': 'application/json' },
+    });
+
+    // First request — populate cache
+    await fetchWithCachedResponse('https://example.com/api/data');
+
+    // Advance past the 10s stale-if-error window (11 seconds)
+    jest.advanceTimersByTime(11000);
+
+    // Second request: network error, but stale-if-error=10 has expired
+    fetchMock.mockAbortOnce();
+
+    // Should throw because stale-if-error window has expired
+    await expect(
+      fetchWithCachedResponse('https://example.com/api/data', {
+        headers: new Headers({ 'Cache-Control': 'stale-if-error=10' }),
+      }),
+    ).rejects.toThrow();
+  });
+
   it('should respect stale-if-error on network faults', async () => {
     fetchMock.mockResponseOnce(JSON.stringify({ name: 'John' }), {
       headers: { ETag: 'abc123', 'content-type': 'application/json' },

--- a/packages/edge-config/src/utils/fetch-with-cached-response.ts
+++ b/packages/edge-config/src/utils/fetch-with-cached-response.ts
@@ -48,7 +48,7 @@ function createHandleStaleIfError(
       case 503:
       case 504:
         return typeof staleIfError === 'number' &&
-          cachedResponseEntry.time < Date.now() + staleIfError * 1000
+          Date.now() < cachedResponseEntry.time + staleIfError * 1000
           ? createResponse(cachedResponseEntry)
           : response;
       default:
@@ -69,7 +69,7 @@ function createHandleStaleIfErrorException(
   ): ResponseWithCachedResponse {
     if (
       typeof staleIfError === 'number' &&
-      cachedResponseEntry.time < Date.now() + staleIfError * 1000
+      Date.now() < cachedResponseEntry.time + staleIfError * 1000
     ) {
       return createResponse(cachedResponseEntry);
     }


### PR DESCRIPTION
## Summary

The stale-if-error cache expiry check in `fetch-with-cached-response.ts` was inverted, causing stale-if-error caches to \*\*never expire\*\* — they would indefinitely serve stale content regardless of how much time passed.

## Bug

The condition compared:
```ts
cachedResponseEntry.time < Date.now() + staleIfError * 1000
```

This evaluates to `true` for any positive `staleIfError` because `Date.now() + staleIfError * 1000` is always in the future. The cache entry time is always less than a future timestamp, so stale content is served forever.

## Fix

Changed the comparison (in both `handleStaleIfError` and `handleStaleIfErrorException`) to:
```ts
Date.now() < cachedResponseEntry.time + staleIfError * 1000
```

This correctly checks whether `Date.now()` has exceeded the cache entry time plus the stale-if-error window — only serving stale content when the window has not yet elapsed.

## Test

Added a regression test: after advancing time past the stale-if-error window (11s past a 10s `stale-if-error=10`), a network-fault fetch should throw — not serve stale content. The test fails before the fix and passes after.