### PR TITLE
fix(blob): raise undici floor to ^6.27.0 to exclude CVE-2026-12151

### DIFF
--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -60,7 +60,7 @@
     "is-buffer": "^2.0.5",
     "is-node-process": "^1.2.0",
     "throttleit": "^2.1.0",
-    "undici": "^6.23.0"
+    "undici": "^6.27.0"
   },
   "devDependencies": {
     "@edge-runtime/jest-environment": "4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       undici:
-        specifier: ^6.23.0
-        version: 6.23.0
+        specifier: ^6.27.0
+        version: 6.28.0
     devDependencies:
       '@edge-runtime/jest-environment':
         specifier: 4.0.0
@@ -3485,8 +3485,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.23.0:
-    resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
   undici@7.19.0:
@@ -6889,7 +6889,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.23.0: {}
+  undici@6.28.0: {}
 
   undici@7.19.0: {}
 


### PR DESCRIPTION
## Summary

Raises the `undici` dependency floor for `@vercel/blob` from `^6.23.0` to `^6.27.0`.

The previous range (`^6.23.0`) still resolves versions affected by CVE-2026-12151 (GHSA-vxpw-j846-p89q), a request-smuggling vulnerability in undici. Pinning the floor to `^6.27.0` guarantees any install of `@vercel/blob` pulls a patched undici, without forcing a breaking major upgrade.

## Changes

- `packages/blob/package.json`: `"undici": "^6.23.0"` → `"^6.27.0"`
- `pnpm-lock.yaml`: synced via `pnpm install --lockfile-only` — now resolves `undici@6.28.0` (undici-only diff)

## Tests

All three test environments pass on `undici@6.28.0`:

- `test:node` — 6 suites, 172 tests, 20 snapshots ✅
- `test:edge` — 1 suite, 1 test, 2 snapshots ✅
- `test:browser` — 3 suites, 19 tests, 3 snapshots ✅

Fixes #1090
