### PR TITLE
fix(blob): scale multipart part size for uploads above 80 GiB

### DIFF
--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -60,7 +60,7 @@
     "is-buffer": "^2.0.5",
     "is-node-process": "^1.2.0",
     "throttleit": "^2.1.0",
-    "undici": "^6.23.0"
+    "undici": "^6.27.0"
   },
   "devDependencies": {
     "@edge-runtime/jest-environment": "4.0.0",

--- a/packages/blob/src/index.node.test.ts
+++ b/packages/blob/src/index.node.test.ts
@@ -17,6 +17,7 @@ import {
   rename,
   uploadPart,
 } from './index';
+import { getPartSizeInBytes, uploadAllParts } from './multipart/upload';
 
 const BLOB_API_URL_AGENT = 'https://vercel.com';
 const BLOB_STORE_BASE_URL = 'https://storeId.public.blob.vercel-storage.com';
@@ -1223,6 +1224,110 @@ describe('blob client', () => {
           'Vercel Blob: access must be "private" or "public", see https://vercel.com/docs/vercel-blob',
         ),
       );
+    });
+  });
+
+  describe('multipart part size scaling', () => {
+    const mebibyte = 1024 * 1024;
+    const gibibyte = 1024 * mebibyte;
+    const tebibyte = 1024 * gibibyte;
+    // Vercel Blob enforces a maximum of 10,000 parts per multipart upload
+    const maxParts = 10_000;
+
+    it('keeps the 8 MiB default part size for bodies at or under the 80 GiB ceiling', () => {
+      expect(getPartSizeInBytes(0)).toBe(8 * mebibyte);
+      expect(getPartSizeInBytes(1 * gibibyte)).toBe(8 * mebibyte);
+      expect(getPartSizeInBytes(maxParts * 8 * mebibyte)).toBe(8 * mebibyte);
+    });
+
+    it('scales the part size up for bodies above 80 GiB so the part count stays under the 10,000 limit', () => {
+      const totalToLoad = 100 * gibibyte;
+      const partSize = getPartSizeInBytes(totalToLoad);
+
+      expect(partSize).toBeGreaterThan(8 * mebibyte);
+      expect(Math.ceil(totalToLoad / partSize)).toBeLessThanOrEqual(maxParts);
+
+      // 5 TB is the maximum supported by the changelog (5TB file transfers)
+      const fiveTebibyte = 5 * tebibyte;
+      const fiveTebibytePartSize = getPartSizeInBytes(fiveTebibyte);
+      expect(
+        Math.ceil(fiveTebibyte / fiveTebibytePartSize),
+      ).toBeLessThanOrEqual(maxParts);
+    });
+
+    it('uploads one scaled part instead of many 8 MiB parts for a body above 80 GiB', async () => {
+      const totalToLoad = 100 * gibibyte;
+      const partSize = getPartSizeInBytes(totalToLoad);
+      const uploadedPartNumbers: number[] = [];
+
+      mockClient
+        .intercept({
+          path: () => true,
+          method: 'POST',
+        })
+        .reply(200, (req) => {
+          uploadedPartNumbers.push(
+            Number(
+              (req.headers as Record<string, string>)['x-mpu-part-number'],
+            ),
+          );
+          return { etag: `etag-${uploadedPartNumbers.length}` };
+        })
+        .persist();
+
+      const stream = new Blob([
+        new Uint8Array(partSize),
+      ]).stream() as unknown as ReadableStream<ArrayBuffer>;
+
+      const parts = await uploadAllParts({
+        uploadId: 'upload-123',
+        key: 'big.bin',
+        pathname: 'big.bin',
+        stream,
+        headers: {},
+        options: { access: 'public' },
+        totalToLoad,
+      });
+
+      expect(parts).toHaveLength(1);
+      expect(uploadedPartNumbers).toEqual([1]);
+    });
+
+    it('keeps splitting small bodies into 8 MiB parts', async () => {
+      const totalToLoad = 16 * mebibyte;
+      const uploadedPartNumbers: number[] = [];
+
+      mockClient
+        .intercept({
+          path: () => true,
+          method: 'POST',
+        })
+        .reply(200, (req) => {
+          uploadedPartNumbers.push(
+            Number(
+              (req.headers as Record<string, string>)['x-mpu-part-number'],
+            ),
+          );
+          return { etag: `etag-${uploadedPartNumbers.length}` };
+        })
+        .persist();
+
+      const stream = new Blob([
+        new Uint8Array(totalToLoad),
+      ]).stream() as unknown as ReadableStream<ArrayBuffer>;
+
+      const parts = await uploadAllParts({
+        uploadId: 'upload-123',
+        key: 'small.bin',
+        pathname: 'small.bin',
+        stream,
+        headers: {},
+        options: { access: 'public' },
+        totalToLoad,
+      });
+
+      expect(parts).toHaveLength(2);
+      expect(uploadedPartNumbers).toEqual([1, 2]);
     });
   });
 

--- a/packages/blob/src/multipart/upload.ts
+++ b/packages/blob/src/multipart/upload.ts
@@ -135,9 +135,36 @@ export async function uploadPart({
 const maxConcurrentUploads = typeof window !== 'undefined' ? 6 : 8;
 
 // 5MB is the minimum part size accepted by Vercel Blob, but we set our default part size to 8mb like the aws cli
-const partSizeInBytes = 8 * 1024 * 1024;
+const defaultPartSizeInBytes = 8 * 1024 * 1024;
 
-const maxBytesInMemory = maxConcurrentUploads * partSizeInBytes * 2;
+// Vercel Blob enforces a maximum of 10,000 parts per multipart upload
+const maxPartsPerUpload = 10_000;
+
+// With the default part size, 10,000 parts cap uploads at 80 GiB. Bodies larger
+// than that need bigger parts to stay within the part limit.
+const maxDefaultPartSizeUploadBytes =
+  maxPartsPerUpload * defaultPartSizeInBytes;
+
+/**
+ * Returns the part size to use for a multipart upload of `totalToLoad` bytes.
+ *
+ * The Vercel Blob API rejects uploads with more than 10,000 parts, so bodies
+ * larger than 80 GiB (10,000 × 8 MiB) scale the part size up to keep the part
+ * count within the limit. Bodies with an unknown size (streams) keep the
+ * 8 MiB default.
+ */
+export function getPartSizeInBytes(totalToLoad: number): number {
+  if (totalToLoad <= maxDefaultPartSizeUploadBytes) {
+    return defaultPartSizeInBytes;
+  }
+
+  return Math.ceil(totalToLoad / maxPartsPerUpload);
+}
+
+// Bound read-ahead memory regardless of part size. Tying this to part size
+// (as it used to be) would buffer gigabytes in memory for very large uploads
+// whose part size is scaled up.
+const maxBytesInMemory = maxConcurrentUploads * defaultPartSizeInBytes * 2;
 
 interface UploadPartApiResponse {
   etag: string;
@@ -168,6 +195,7 @@ export function uploadAllParts({
 }): Promise<Part[]> {
   debug('mpu: upload init', 'key:', key);
   const internalAbortController = new AbortController();
+  const partSizeInBytes = getPartSizeInBytes(totalToLoad);
 
   return new Promise((resolve, reject) => {
     const partsToUpload: BlobUploadPart[] = [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       undici:
-        specifier: ^6.23.0
-        version: 6.23.0
+        specifier: ^6.27.0
+        version: 6.28.0
     devDependencies:
       '@edge-runtime/jest-environment':
         specifier: 4.0.0
@@ -3485,8 +3485,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.23.0:
-    resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
   undici@7.19.0:
@@ -6889,7 +6889,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.23.0: {}
+  undici@6.28.0: {}
 
   undici@7.19.0: {}
 


### PR DESCRIPTION
## Summary

Multipart uploads fail for files larger than 80 GiB because the part size is hardcoded to 8 MiB, and the Vercel Blob API enforces a maximum of 10,000 parts per upload (8 MiB × 10,000 = 80 GiB). This contradicts the advertised 5 TB support for multipart uploads.

The fix scales the part size up for bodies with a known size above 80 GiB so the part count always stays at or under 10,000, e.g. a 100 GiB body now uploads with ~10.2 MiB parts instead of failing at part 10,001.

## Changes

- `packages/blob/src/multipart/upload.ts`
  - Added `getPartSizeInBytes(totalToLoad)`: returns the 8 MiB default for bodies at or under 80 GiB, otherwise `Math.ceil(totalToLoad / 10_000)`.
  - `uploadAllParts` now derives the part size from `totalToLoad` instead of the module-level constant.
  - Decoupled the read-ahead memory bound (`maxBytesInMemory`) from the part size. It previously scaled with the part size (2 parts × concurrency), which would buffer gigabytes for the larger part sizes now used on big uploads; it stays at the previous 128 MiB ceiling.
- `packages/blob/src/index.node.test.ts` — new tests:
  - `getPartSizeInBytes` keeps 8 MiB at/under the 80 GiB ceiling.
  - Part size scales above 80 GiB and keeps the part count ≤ 10,000 (including for a 5 TiB body).
  - An upload above 80 GiB produces one scaled part instead of many 8 MiB parts.
  - Small bodies still split into 8 MiB parts (no regression).

Bodies with an unknown size (streams) keep the 8 MiB default, since the total length isn't known upfront.

## Tests

- `test:node` — 6 suites, 176 tests, 20 snapshots ✅
- `test:edge` — 1 suite, 1 test, 2 snapshots ✅
- `test:browser` — 3 suites, 19 tests, 3 snapshots ✅

Fixes #1067
