### PR TITLE
fix(blob): avoid runtime Node stream adapter

### DIFF
--- a/.changeset/clean-plums-smile.md
+++ b/.changeset/clean-plums-smile.md
@@ -1,0 +1,5 @@
+---
+'@vercel/blob': patch
+---
+
+Convert Node.js readable streams without retaining a runtime dependency on the Node.js stream module.

--- a/.changeset/clean-plums-smile.md
+++ b/.changeset/clean-plums-smile.md
@@ -2,4 +2,4 @@
 '@vercel/blob': patch
 ---
 
-Convert Node.js readable streams without retaining a runtime dependency on the Node.js stream module.
+Convert Node.js readable streams without importing the Node.js stream module at runtime.

--- a/packages/blob/src/multipart/helpers.node.test.ts
+++ b/packages/blob/src/multipart/helpers.node.test.ts
@@ -14,10 +14,22 @@ describe('toReadableStream', () => {
     const source = Readable.from([Buffer.from('hello')]);
     const destroy = jest.spyOn(source, 'destroy');
     const stream = await toReadableStream(source);
-    const reason = new Error('cancelled');
+    const reason = 'cancelled';
 
     await stream.cancel(reason);
 
     expect(destroy).toHaveBeenCalledWith(reason);
+  });
+
+  it('forwards Node.js stream errors to the Web stream', async () => {
+    const error = new Error('failed');
+    const source = new Readable({
+      read() {
+        this.destroy(error);
+      },
+    });
+    const stream = await toReadableStream(source);
+
+    await expect(stream.getReader().read()).rejects.toBe(error);
   });
 });

--- a/packages/blob/src/multipart/helpers.node.test.ts
+++ b/packages/blob/src/multipart/helpers.node.test.ts
@@ -1,0 +1,23 @@
+import { Readable } from 'node:stream';
+import { toReadableStream } from './helpers';
+
+describe('toReadableStream', () => {
+  it('converts a Node.js stream to a Web stream', async () => {
+    const stream = await toReadableStream(
+      Readable.from([Buffer.from('hello '), Buffer.from('world')]),
+    );
+
+    await expect(new Response(stream).text()).resolves.toBe('hello world');
+  });
+
+  it('destroys the Node.js stream when the Web stream is cancelled', async () => {
+    const source = Readable.from([Buffer.from('hello')]);
+    const destroy = jest.spyOn(source, 'destroy');
+    const stream = await toReadableStream(source);
+    const reason = new Error('cancelled');
+
+    await stream.cancel(reason);
+
+    expect(destroy).toHaveBeenCalledWith(reason);
+  });
+});

--- a/packages/blob/src/multipart/helpers.node.test.ts
+++ b/packages/blob/src/multipart/helpers.node.test.ts
@@ -1,35 +1,32 @@
 import { Readable } from 'node:stream';
 import { toReadableStream } from './helpers';
 
-describe('toReadableStream', () => {
-  it('converts a Node.js stream to a Web stream', async () => {
-    const stream = await toReadableStream(
-      Readable.from([Buffer.from('hello '), Buffer.from('world')]),
-    );
+it('converts a Node.js stream to a Web stream', async () => {
+  const stream = await toReadableStream(
+    Readable.from([Buffer.from('hello '), Buffer.from('world')]),
+  );
 
-    await expect(new Response(stream).text()).resolves.toBe('hello world');
+  await expect(new Response(stream).text()).resolves.toBe('hello world');
+});
+
+it('destroys the source stream when cancelled', async () => {
+  const source = Readable.from([Buffer.from('hello')]);
+  const destroy = jest.spyOn(source, 'destroy');
+  const stream = await toReadableStream(source);
+
+  await stream.cancel('cancelled');
+
+  expect(destroy).toHaveBeenCalledWith('cancelled');
+});
+
+it('forwards source stream errors', async () => {
+  const error = new Error('failed');
+  const source = new Readable({
+    read() {
+      this.destroy(error);
+    },
   });
+  const stream = await toReadableStream(source);
 
-  it('destroys the Node.js stream when the Web stream is cancelled', async () => {
-    const source = Readable.from([Buffer.from('hello')]);
-    const destroy = jest.spyOn(source, 'destroy');
-    const stream = await toReadableStream(source);
-    const reason = 'cancelled';
-
-    await stream.cancel(reason);
-
-    expect(destroy).toHaveBeenCalledWith(reason);
-  });
-
-  it('forwards Node.js stream errors to the Web stream', async () => {
-    const error = new Error('failed');
-    const source = new Readable({
-      read() {
-        this.destroy(error);
-      },
-    });
-    const stream = await toReadableStream(source);
-
-    await expect(stream.getReader().read()).rejects.toBe(error);
-  });
+  await expect(stream.getReader().read()).rejects.toBe(error);
 });

--- a/packages/blob/src/multipart/helpers.ts
+++ b/packages/blob/src/multipart/helpers.ts
@@ -1,6 +1,6 @@
 import type { Buffer } from 'buffer';
 import isBuffer from 'is-buffer';
-import { Readable } from 'stream';
+import type { Readable } from 'stream';
 import type { PutBody } from '../put-helpers';
 
 /**
@@ -72,7 +72,27 @@ export async function toReadableStream(
   }
 
   if (isNodeJsReadableStream(value)) {
-    return Readable.toWeb(value) as ReadableStream<ArrayBuffer>;
+    const iterator = value[Symbol.asyncIterator]();
+
+    return new ReadableStream({
+      async pull(controller) {
+        const result = await iterator.next();
+
+        if (result.done) {
+          controller.close();
+        } else {
+          controller.enqueue(
+            result.value instanceof Uint8Array
+              ? new Uint8Array(result.value)
+              : result.value,
+          );
+        }
+      },
+      async cancel(reason) {
+        value.destroy(reason instanceof Error ? reason : undefined);
+        await iterator.return?.();
+      },
+    });
   }
 
   let streamValue: Uint8Array;

--- a/packages/blob/src/multipart/helpers.ts
+++ b/packages/blob/src/multipart/helpers.ts
@@ -89,7 +89,7 @@ export async function toReadableStream(
         }
       },
       async cancel(reason) {
-        value.destroy(reason instanceof Error ? reason : undefined);
+        value.destroy(reason);
         await iterator.return?.();
       },
     });

--- a/packages/blob/src/multipart/helpers.ts
+++ b/packages/blob/src/multipart/helpers.ts
@@ -76,17 +76,16 @@ export async function toReadableStream(
 
     return new ReadableStream({
       async pull(controller) {
-        const result = await iterator.next();
+        const { done, value: chunk } = await iterator.next();
 
-        if (result.done) {
+        if (done) {
           controller.close();
-        } else {
-          controller.enqueue(
-            result.value instanceof Uint8Array
-              ? new Uint8Array(result.value)
-              : result.value,
-          );
+          return;
         }
+
+        controller.enqueue(
+          chunk instanceof Uint8Array ? new Uint8Array(chunk) : chunk,
+        );
       },
       async cancel(reason) {
         value.destroy(reason);


### PR DESCRIPTION
`@vercel/blob` imported Node's `stream` module only to convert Node readable streams. That stops Vite and Rolldown from bundling the package for runtimes without the module, so [vite-hub/vitehub#1095](https://github.com/vite-hub/vitehub/pull/1095) currently patches it.

`toReadableStream` now consumes the stream's async iterator, leaving the Node import type-only. Upload data, errors, and cancellation still pass through, and the PR includes a patch changeset.
